### PR TITLE
Filter blog posts by status and remove images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2025-10-13
+### Added
+- logfire and sentry monitoring
+- status field on blogpost model to only show published
+
+### Removed
+- icons and images from blog posts
 
 ## [0.0.1] - 2025-10-13
 **Added**

--- a/core/views.py
+++ b/core/views.py
@@ -88,6 +88,11 @@ class BlogView(ListView):
     context_object_name = "blog_posts"
     ordering = ["-created_at"]
 
+    def get_queryset(self):
+        from core.choices import BlogPostStatus
+
+        return BlogPost.objects.filter(status=BlogPostStatus.PUBLISHED).order_by("-created_at")
+
 
 class BlogPostView(DetailView):
     model = BlogPost

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -13,7 +13,7 @@
 <meta property="og:title" content="{{ blog_post.title }}" />
 <meta property="og:url" content="https://{{ request.get_host }}{{ blog_post.get_absolute_url }}" />
 <meta property="og:description" content="{{ blog_post.description }}" />
-<meta property="og:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+<meta property="og:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}" />
 <meta property="og:locale" content="en_US" />
 
 <meta name="twitter:card" content="summary_large_image" />
@@ -21,7 +21,7 @@
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="{{ blog_post.title }}" />
 <meta name="twitter:description" content="{{ blog_post.description }}" />
-<meta name="twitter:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+<meta name="twitter:image" content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}" />
 {% endblock meta %}
 
 {% block content %}
@@ -43,7 +43,7 @@
     "@type": "BlogPosting",
     "headline": "{{ blog_post.title }}",
     "description": "{{ blog_post.description }}",
-    "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}",
+    "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }}&subtitle={{ blog_post.description }}",
     "url": "https://{{ request.get_host }}{{ blog_post.get_absolute_url }}",
     "datePublished": "{{ blog_post.created_at|date:'c' }}",
     "dateModified": "{{ blog_post.updated_at|date:'c' }}",

--- a/frontend/templates/blog/blog_posts.html
+++ b/frontend/templates/blog/blog_posts.html
@@ -31,14 +31,9 @@
       <div class="space-y-4">
         {% for post in blog_posts %}
           <a href="{{ post.get_absolute_url }}" class="block rounded-lg transition duration-150 ease-in-out hover:bg-gray-100">
-            <article class="flex items-start p-4">
-              {% if post.icon %}
-                <img src="{{ post.icon.url }}" alt="{{ post.title }}" class="object-cover flex-shrink-0 mr-4 w-24 h-24 rounded-lg">
-              {% endif %}
-              <div>
-                <h2 class="mb-2 text-2xl font-semibold text-gray-900">{{ post.title }}</h2>
-                <p class="text-gray-600">{{ post.description }}</p>
-              </div>
+            <article class="p-4">
+              <h2 class="mb-2 text-2xl font-semibold text-gray-900">{{ post.title }}</h2>
+              <p class="text-gray-600">{{ post.description }}</p>
             </article>
           </a>
         {% endfor %}


### PR DESCRIPTION
Implemented filtering in the `BlogView` to display only blog posts that are explicitly marked as `PUBLISHED`. This ensures that draft or unpublished content is not accessible to site visitors.

Additionally, blog post icons were removed from the main blog listing page (`blog_posts.html`). Individual blog post images were also removed from social media sharing meta tags (Open Graph, Twitter Card) and schema.org JSON-LD data in `blog_post.html`. These changes streamline content presentation and reduce reliance on specific image assets per blog post for display and social sharing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog lists now show only published posts.
* **Style**
  * Simplified blog list layout by removing post icons for a cleaner look.
* **Bug Fixes**
  * Improved social sharing previews by removing embedded image URLs from meta tags and JSON-LD.
* **Chores**
  * Added application monitoring to improve observability.
* **Documentation**
  * Updated changelog with release 0.0.2 (2025-10-13) outlining notable changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->