### PR TITLE
feat(osig): Signed OG URLs, format controls, and cache toolkit

### DIFF
--- a/core/api/schemas.py
+++ b/core/api/schemas.py
@@ -17,3 +17,13 @@ class BlogPostIn(Schema):
 class BlogPostOut(Schema):
     status: str
     message: str
+
+
+class SignOgUrlIn(Schema):
+    params: dict[str, str | int | float | bool]
+    expires_in_seconds: int = 3600
+
+
+class SignOgUrlOut(Schema):
+    signed_url: str
+    expires_at: str

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -1,9 +1,13 @@
+from urllib.parse import urlencode
+
 from django.http import HttpRequest
+from django.urls import reverse
 from ninja import NinjaAPI
 
 from core.api.auth import superuser_api_auth
-from core.api.schemas import BlogPostIn, BlogPostOut
+from core.api.schemas import BlogPostIn, BlogPostOut, SignOgUrlIn, SignOgUrlOut
 from core.models import BlogPost
+from core.signing import build_signed_params
 
 api = NinjaAPI(docs_url=None)
 
@@ -23,3 +27,20 @@ def submit_blog_post(request: HttpRequest, data: BlogPostIn):
         return BlogPostOut(status="success", message="Blog post submitted successfully.")
     except Exception as e:
         return BlogPostOut(status="error", message=f"Failed to submit blog post: {str(e)}")
+
+
+@api.post("/sign", response=SignOgUrlOut)
+def sign_og_url(request: HttpRequest, data: SignOgUrlIn):
+    base_url = request.build_absolute_uri(reverse("generate_image"))
+
+    signed_params, expires_at = build_signed_params(
+        params=data.params,
+        expires_in_seconds=data.expires_in_seconds,
+    )
+
+    signed_url = f"{base_url}?{urlencode(signed_params)}"
+
+    return SignOgUrlOut(
+        signed_url=signed_url,
+        expires_at=expires_at.isoformat(),
+    )

--- a/core/image_styles.py
+++ b/core/image_styles.py
@@ -25,6 +25,9 @@ def generate_image_router(image_data):
             title=image_data.get("title"),
             subtitle=image_data.get("subtitle"),
             image_url=image_data.get("image_url"),
+            output_format=image_data.get("format", "png"),
+            quality=image_data.get("quality"),
+            max_kb=image_data.get("max_kb"),
         )
     else:
         return generate_base_image(
@@ -35,6 +38,9 @@ def generate_image_router(image_data):
             subtitle=image_data.get("subtitle"),
             eyebrow=image_data.get("eyebrow"),
             image_url=image_data.get("image_url"),
+            output_format=image_data.get("format", "png"),
+            quality=image_data.get("quality"),
+            max_kb=image_data.get("max_kb"),
         )
 
 
@@ -46,6 +52,9 @@ def generate_base_image(
     subtitle,
     eyebrow,
     image_url,
+    output_format="png",
+    quality=None,
+    max_kb=None,
 ):
     logger.info(
         "Generating base OG image",
@@ -128,10 +137,20 @@ def generate_base_image(
     if not has_pro_subscription:
         add_watermark(img, draw, width, height)
 
-    return create_image_buffer(img)
+    return create_image_buffer(img, output_format=output_format, quality=quality, max_kb=max_kb)
 
 
-def generate_logo_image(profile_id, site, font, title, subtitle, image_url):
+def generate_logo_image(
+    profile_id,
+    site,
+    font,
+    title,
+    subtitle,
+    image_url,
+    output_format="png",
+    quality=None,
+    max_kb=None,
+):
     logger.info(
         "Generating logo OG image",
         profile_id=profile_id,
@@ -199,4 +218,4 @@ def generate_logo_image(profile_id, site, font, title, subtitle, image_url):
     if not has_pro_subscription:
         add_watermark(img, draw, width, height)
 
-    return create_image_buffer(img)
+    return create_image_buffer(img, output_format=output_format, quality=quality, max_kb=max_kb)

--- a/core/signing.py
+++ b/core/signing.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone as dt_timezone
+from typing import Any, Mapping
+from urllib.parse import urlencode
+
+from django.core import signing
+from django.utils import timezone
+from django.utils.crypto import constant_time_compare
+
+SIGNATURE_PARAM = "sig"
+EXPIRES_AT_PARAM = "exp"
+SIGNING_SALT = "core.og-url-signature"
+
+DEFAULT_SIGNED_URL_TTL_SECONDS = 60 * 60
+MAX_SIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 30
+
+
+class SignedUrlError(ValueError):
+    pass
+
+
+class InvalidSignatureError(SignedUrlError):
+    pass
+
+
+class ExpiredSignatureError(SignedUrlError):
+    pass
+
+
+def _canonical_items(params: Mapping[str, Any]) -> list[tuple[str, str]]:
+    items: list[tuple[str, str]] = []
+    for key in sorted(params.keys()):
+        if key == SIGNATURE_PARAM:
+            continue
+
+        value = params[key]
+        if value is None:
+            continue
+
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                items.append((key, str(item)))
+        else:
+            items.append((key, str(value)))
+
+    return items
+
+
+def build_signature_payload(params: Mapping[str, Any]) -> str:
+    return urlencode(_canonical_items(params), doseq=True)
+
+
+def _clamp_ttl(expires_in_seconds: int) -> int:
+    return max(1, min(int(expires_in_seconds), MAX_SIGNED_URL_TTL_SECONDS))
+
+
+def build_signed_params(
+    params: Mapping[str, Any],
+    expires_in_seconds: int = DEFAULT_SIGNED_URL_TTL_SECONDS,
+    now: datetime | None = None,
+) -> tuple[dict[str, str], datetime]:
+    current_time = now or timezone.now()
+    ttl_seconds = _clamp_ttl(expires_in_seconds)
+    expires_at = current_time + timedelta(seconds=ttl_seconds)
+
+    normalized_params: dict[str, str] = {
+        key: str(value)
+        for key, value in params.items()
+        if value is not None and key not in {SIGNATURE_PARAM, EXPIRES_AT_PARAM}
+    }
+    normalized_params[EXPIRES_AT_PARAM] = str(int(expires_at.timestamp()))
+
+    signer = signing.Signer(salt=SIGNING_SALT)
+    payload = build_signature_payload(normalized_params)
+    signature = signer.signature(payload)
+
+    signed_params = dict(normalized_params)
+    signed_params[SIGNATURE_PARAM] = signature
+
+    return signed_params, expires_at
+
+
+def verify_signed_params(params: Mapping[str, Any], now: datetime | None = None) -> datetime | None:
+    signature = params.get(SIGNATURE_PARAM)
+    if not signature:
+        return None
+
+    expires_at_raw = params.get(EXPIRES_AT_PARAM)
+    if not expires_at_raw:
+        raise InvalidSignatureError("Missing exp parameter")
+
+    try:
+        expires_at_ts = int(str(expires_at_raw))
+    except ValueError as exc:
+        raise InvalidSignatureError("Invalid exp parameter") from exc
+
+    expires_at = datetime.fromtimestamp(expires_at_ts, tz=dt_timezone.utc)
+    current_time = now or timezone.now()
+    if current_time > expires_at:
+        raise ExpiredSignatureError("Signed URL has expired")
+
+    signer = signing.Signer(salt=SIGNING_SALT)
+
+    normalized_params: dict[str, str] = {
+        key: str(value)
+        for key, value in params.items()
+        if value is not None and key != SIGNATURE_PARAM
+    }
+
+    payload = build_signature_payload(normalized_params)
+    expected_signature = signer.signature(payload)
+
+    if not constant_time_compare(str(signature), expected_signature):
+        raise InvalidSignatureError("Signature mismatch")
+
+    return expires_at

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -13,9 +13,13 @@ from osig.utils import get_osig_logger
 logger = get_osig_logger(__name__)
 
 
+def _get_output_extension(image_data):
+    return "jpeg" if image_data.get("format") == "jpeg" else "png"
+
+
 def save_generated_image(image, image_data):
     prefix = "key_" if image_data.get("key") else "no_key_"
-    image_filename = f"{prefix}{uuid.uuid4().hex[:12]}.png"
+    image_filename = f"{prefix}{uuid.uuid4().hex[:12]}.{_get_output_extension(image_data)}"
 
     try:
         with transaction.atomic():
@@ -43,7 +47,7 @@ def regenerate_and_update_image(image_id, image_data):
             return "Old image not found in S3, skipping regeneration"
 
         prefix = "key_" if image_data.get("key") else "no_key_"
-        image_filename = f"{prefix}{uuid.uuid4().hex[:12]}.png"
+        image_filename = f"{prefix}{uuid.uuid4().hex[:12]}.{_get_output_extension(image_data)}"
         image_content = ContentFile(new_image.getvalue())
 
         for key, value in image_data.items():

--- a/core/tests/test_generate_image_features.py
+++ b/core/tests/test_generate_image_features.py
@@ -1,0 +1,197 @@
+import io
+import json
+from datetime import timedelta
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.utils import timezone
+from PIL import Image
+
+from core.signing import build_signed_params
+
+
+@pytest.fixture
+def disable_async_tasks(monkeypatch):
+    import core.views as core_views
+
+    monkeypatch.setattr(core_views, "async_task", lambda *args, **kwargs: None)
+
+
+def _tiny_png_buffer():
+    buffer = io.BytesIO()
+    Image.new("RGB", (16, 16), color="white").save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer
+
+
+@pytest.mark.django_db
+class TestSignedUrls:
+    def test_sign_endpoint_returns_signed_og_url(self, client):
+        payload = {
+            "params": {
+                "style": "base",
+                "site": "x",
+                "title": "Signed title",
+                "subtitle": "Signed subtitle",
+            },
+            "expires_in_seconds": 300,
+        }
+
+        response = client.post("/api/sign", data=json.dumps(payload), content_type="application/json")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        signed_url = data["signed_url"]
+        parsed = urlparse(signed_url)
+        parsed_query = parse_qs(parsed.query)
+
+        assert parsed.path == "/g"
+        assert parsed_query["title"] == ["Signed title"]
+        assert "sig" in parsed_query
+        assert "exp" in parsed_query
+
+    def test_generate_image_accepts_valid_signature(self, client, disable_async_tasks, monkeypatch):
+        import core.views as core_views
+
+        monkeypatch.setattr(core_views, "generate_image_router", lambda params: _tiny_png_buffer())
+
+        signed_params, _ = build_signed_params(
+            {
+                "style": "base",
+                "site": "x",
+                "title": "Valid Signature",
+                "subtitle": "Works",
+            },
+            expires_in_seconds=300,
+        )
+
+        response = client.get("/g", data=signed_params)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "image/png"
+        assert "max-age=" in response["Cache-Control"]
+        assert "immutable" not in response["Cache-Control"]
+
+    def test_generate_image_rejects_tampered_signature(self, client, disable_async_tasks, monkeypatch):
+        import core.views as core_views
+
+        monkeypatch.setattr(core_views, "generate_image_router", lambda params: _tiny_png_buffer())
+
+        signed_params, _ = build_signed_params(
+            {
+                "style": "base",
+                "site": "x",
+                "title": "Original Title",
+            },
+            expires_in_seconds=300,
+        )
+        signed_params["title"] = "Tampered Title"
+
+        response = client.get("/g", data=signed_params)
+
+        assert response.status_code == 403
+
+    def test_generate_image_rejects_expired_signature(self, client, disable_async_tasks, monkeypatch):
+        import core.views as core_views
+
+        monkeypatch.setattr(core_views, "generate_image_router", lambda params: _tiny_png_buffer())
+
+        signed_params, _ = build_signed_params(
+            {
+                "style": "base",
+                "site": "x",
+                "title": "Expired Signature",
+            },
+            expires_in_seconds=60,
+            now=timezone.now() - timedelta(hours=2),
+        )
+
+        response = client.get("/g", data=signed_params)
+
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestOutputFormatAndCompression:
+    def test_generate_image_supports_png_and_jpeg_content_types(self, client, disable_async_tasks):
+        common_params = {
+            "style": "base",
+            "site": "x",
+            "title": "Format Test",
+            "subtitle": "Content types",
+        }
+
+        png_response = client.get("/g", data={**common_params, "format": "png"})
+        jpeg_response = client.get("/g", data={**common_params, "format": "jpeg", "quality": "70"})
+
+        assert png_response.status_code == 200
+        assert png_response["Content-Type"] == "image/png"
+
+        assert jpeg_response.status_code == 200
+        assert jpeg_response["Content-Type"] == "image/jpeg"
+        assert jpeg_response.content.startswith(b"\xff\xd8")
+
+    def test_jpeg_quality_output_is_deterministic(self, client, disable_async_tasks):
+        params = {
+            "style": "base",
+            "site": "x",
+            "title": "Deterministic",
+            "subtitle": "JPEG quality",
+            "format": "jpeg",
+            "quality": "62",
+        }
+
+        first = client.get("/g", data=params)
+        second = client.get("/g", data=params)
+        lower_quality = client.get("/g", data={**params, "quality": "20"})
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.content == second.content
+        assert first.content != lower_quality.content
+
+
+@pytest.mark.django_db
+class TestCacheAndVersioning:
+    def test_v_query_param_changes_cache_key_lookup(self, client, disable_async_tasks, monkeypatch):
+        import core.views as core_views
+
+        requested_image_data = []
+
+        def fake_filter(*args, **kwargs):
+            image_data = kwargs["image_data"]
+            requested_image_data.append(dict(image_data))
+
+            version = image_data.get("v")
+            payload = b"image-v1" if version == "1" else b"image-v2"
+            cached_object = SimpleNamespace(
+                id=1,
+                generated_image=payload,
+                updated_at=timezone.now(),
+            )
+            return SimpleNamespace(first=lambda: cached_object)
+
+        monkeypatch.setattr(core_views.ImageModel.objects, "filter", fake_filter)
+
+        response_v1 = client.get("/g", data={"style": "base", "title": "Cache", "v": "1"})
+        response_v2 = client.get("/g", data={"style": "base", "title": "Cache", "v": "2"})
+
+        assert response_v1.status_code == 200
+        assert response_v2.status_code == 200
+        assert response_v1.content == b"image-v1"
+        assert response_v2.content == b"image-v2"
+
+        assert requested_image_data[0]["v"] == "1"
+        assert requested_image_data[1]["v"] == "2"
+
+    def test_generate_image_sets_explicit_cache_headers(self, client, disable_async_tasks, monkeypatch):
+        import core.views as core_views
+
+        monkeypatch.setattr(core_views, "generate_image_router", lambda params: _tiny_png_buffer())
+
+        response = client.get("/g", data={"style": "base", "title": "Cache headers"})
+
+        assert response.status_code == 200
+        assert response["Cache-Control"] == "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary
Implemented Wave 1 tasks 1-3 for OSIG ICP sprint in a single PR:

1) **Signed URL generator**
- Added new API endpoint `POST /api/sign` to sign OG image parameters.
- Signed URLs include `exp` and `sig` and support configurable TTL via `expires_in_seconds`.
- `GET /g` validates signatures with `django.core.signing`:
  - tampered params -> `403`
  - missing/invalid/expired signature -> `403`
- Existing unsigned `/g` behavior remains supported (backward compatibility).

2) **Output format + compression controls**
- Added `format=png|jpeg` support for `/g`.
- Added deterministic `quality` handling:
  - JPEG defaults to 85.
  - Clamped to 1..100.
  - PNG compresses using `compress_level` and optional quality when provided.
- Added optional `max_kb` (best-effort JPEG size target).
- Enforced response `Content-Type` via output format (`image/png` / `image/jpeg`).

3) **Cache/versioning toolkit**
- Added optional `v` query param into image cache key input.
- Added explicit cache-control headers:
  - Unsigned: `public, max-age=31536000, immutable`
  - Signed: `public, max-age=<seconds until exp>`
- Added cache-busting / social-preview refresh workflow documentation.

## Testing
- `ENVIRONMENT=dev SECRET_KEY=test DEBUG=off ALLOWED_HOSTS=localhost,127.0.0.1,testserver CSRF_TRUSTED_ORIGINS=http://localhost,http://testserver DATABASE_URL=sqlite:////tmp/osig-test.db AWS_S3_ENDPOINT_URL=http://localhost AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test GITHUB_CLIENT_ID=test GITHUB_CLIENT_SECRET=test MAILGUN_API_KEY=test REDIS_URL=redis://localhost:6379/0 BUTTONDOWN_API_KEY=test POSTHOG_API_KEY=test STRIPE_LIVE_SECRET_KEY=test STRIPE_TEST_SECRET_KEY=test DJSTRIPE_WEBHOOK_SECRET=test DJANGO_LOG_LEVEL=INFO uv run --with-requirements requirements.txt --with pytest pytest core/tests/test_generate_image_features.py -q`
  - **Result:** `8 passed`
- `ENVIRONMENT=dev ... uv run --with-requirements requirements.txt --with pytest pytest core/tests -q --ignore=core/tests/test_views.py`
  - **Result:** `8 passed`

Remaining baseline: `core/tests/test_views.py` requires frontend build artifacts (`frontend/build/manifest.json`) in this runtime environment and is unchanged by this PR.

## Migration / compatibility notes
- No migrations required.
- Existing unsigned `/g` requests are still accepted with current behavior unchanged.
- Signed generation is additive / versioned via signature metadata and optional params.

## Risks / blockers
- In test environment, full-suite homepage view tests depend on a generated webpack manifest file that is not present here.
- Compression tuning (`max_kb`) is currently implemented as best-effort for JPEG only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added signed URL generation via POST /api/sign for secure, tamper-proof OG image links with expiration support.
  * Added JPEG output format option with adjustable quality (1-100) and size control (max_kb).
  * Added cache-busting version parameter (v) for cache key rotation.

* **Documentation**
  * Updated API documentation with signed URL workflow, output controls, and cache/versioning guidance.
  * Added social preview refresh checklist for image revalidation on social platforms.

* **Tests**
  * Added comprehensive tests covering signed URLs, output formats, and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->