### PR TITLE
feat(osig): add job-board template pack v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Below is a list of all parameters we currently support:
 *   **style**: Image style (default: "base")
     *   \- [base](#base)
     *   \- [logo](#logo)
+    *   \- [job_classic](#job-board-template-pack-v1)
+    *   \- [job_logo](#job-board-template-pack-v1)
+    *   \- [job_clean](#job-board-template-pack-v1)
 *   **site**: This dictates the size of the image (default: "x")
     *   \- x (1600 by 900)
     *   \- meta (1200 by 630)
@@ -33,6 +36,7 @@ Below is a list of all parameters we currently support:
 *   **subtitle**: Subtitle text
 *   **eyebrow**: Eyebrow text
 *   **image\_url**: URL of the background image
+*   **image\_or\_logo**: Alias for `image_url`, recommended for job-board templates where the asset can be either a hero image or company logo.
 *   **format**: Output format (`png` or `jpeg`, default: `png`)
 *   **quality**: Compression quality (`1-100`).
     * For `jpeg`: defaults to `85` if omitted.
@@ -91,6 +95,36 @@ https://osig.app/g?
   &title=Narrative
   &subtitle=Founding Senior Software Engineer
   &image_url=http://res.cloudinary.com/built-with-django/image/upload/v1728024021/user-profile-image-prod/hhxfplsthiaytuttoamc.jpg
+```
+
+#### Job-board template pack v1
+
+Wave 1 ships three production-ready job-board styles:
+
+- `job_classic`: full-bleed background + high-contrast copy
+- `job_logo`: role-focused copy with circular logo slot
+- `job_clean`: minimal white layout with accent bar and logo slot
+
+All three templates support the same core fields:
+
+- `title`
+- `subtitle`
+- `eyebrow`
+- `image_or_logo` (alias for `image_url`)
+
+Copy is safely truncated to keep layouts stable for long job titles/descriptions.
+
+Example:
+
+```
+https://osig.app/g?
+  site=x
+  &style=job_logo
+  &font=helvetica
+  &title=Senior Django Engineer
+  &subtitle=Build reliable product features and own the roadmap.
+  &eyebrow=Remote · Full-time
+  &image_or_logo=https://example.com/company-logo.png
 ```
 
 ### Fonts

--- a/core/image_styles.py
+++ b/core/image_styles.py
@@ -14,34 +14,128 @@ from osig.utils import get_osig_logger
 logger = get_osig_logger(__name__)
 
 
+def _safe_truncate(text, max_chars):
+    if not text:
+        return ""
+
+    normalized_text = " ".join(str(text).split())
+    if len(normalized_text) <= max_chars:
+        return normalized_text
+
+    if max_chars <= 3:
+        return normalized_text[:max_chars]
+
+    return f"{normalized_text[: max_chars - 3].rstrip()}..."
+
+
+def _normalize_job_copy(title, subtitle, eyebrow):
+    return (
+        _safe_truncate(title, 110),
+        _safe_truncate(subtitle, 180),
+        _safe_truncate(eyebrow, 55),
+    )
+
+
+def _draw_wrapped_text_block(draw, text, font, max_width, x_position, y_position, text_color, text_spacing, **kwargs):
+    if not text:
+        return y_position
+
+    is_title = kwargs.get("is_title", False)
+    height = kwargs.get("height")
+
+    words = text.split()
+    lines = []
+    current_line = []
+
+    for word in words:
+        test_line = " ".join(current_line + [word])
+        bbox = font.getbbox(test_line)
+        if bbox[2] <= max_width:
+            current_line.append(word)
+        else:
+            if current_line:
+                lines.append(" ".join(current_line))
+                current_line = [word]
+            else:
+                lines.append(word)
+
+    if current_line:
+        lines.append(" ".join(current_line))
+
+    for line in lines:
+        bbox = font.getbbox(line)
+
+        if is_title and height:
+            bold_offset = int(height * 0.002)
+            for offset_x in range(-bold_offset - 1, bold_offset + 1):
+                for offset_y in range(-bold_offset, bold_offset + 1):
+                    draw.text((x_position + offset_x, y_position + offset_y), line, font=font, fill=text_color)
+        else:
+            draw.text((x_position, y_position), line, font=font, fill=text_color)
+
+        y_position += bbox[3] - bbox[1] + text_spacing
+
+    return y_position
+
+
+def _load_optional_image(image_url, width, height):
+    if not image_url:
+        return None
+
+    try:
+        return load_and_resize_image(image_url, width, height)
+    except Exception as e:
+        logger.warning("Failed to load remote image", image_url=image_url, error=str(e))
+        return None
+
+
 def generate_image_router(image_data):
     style = image_data.get("style", "base")
+    image_url = image_data.get("image_url") or image_data.get("image_or_logo")
+
+    common_kwargs = {
+        "profile_id": image_data.get("profile_id"),
+        "site": image_data.get("site"),
+        "font": image_data.get("font"),
+        "title": image_data.get("title"),
+        "subtitle": image_data.get("subtitle"),
+        "output_format": image_data.get("format", "png"),
+        "quality": image_data.get("quality"),
+        "max_kb": image_data.get("max_kb"),
+    }
 
     if style == "logo":
         return generate_logo_image(
-            profile_id=image_data.get("profile_id"),
-            site=image_data.get("site"),
-            font=image_data.get("font"),
-            title=image_data.get("title"),
-            subtitle=image_data.get("subtitle"),
-            image_url=image_data.get("image_url"),
-            output_format=image_data.get("format", "png"),
-            quality=image_data.get("quality"),
-            max_kb=image_data.get("max_kb"),
+            image_url=image_url,
+            **common_kwargs,
         )
-    else:
-        return generate_base_image(
-            profile_id=image_data.get("profile_id"),
-            site=image_data.get("site"),
-            font=image_data.get("font"),
-            title=image_data.get("title"),
-            subtitle=image_data.get("subtitle"),
+
+    if style == "job_classic":
+        return generate_job_classic_image(
             eyebrow=image_data.get("eyebrow"),
-            image_url=image_data.get("image_url"),
-            output_format=image_data.get("format", "png"),
-            quality=image_data.get("quality"),
-            max_kb=image_data.get("max_kb"),
+            image_url=image_url,
+            **common_kwargs,
         )
+
+    if style == "job_logo":
+        return generate_job_logo_image(
+            eyebrow=image_data.get("eyebrow"),
+            image_url=image_url,
+            **common_kwargs,
+        )
+
+    if style == "job_clean":
+        return generate_job_clean_image(
+            eyebrow=image_data.get("eyebrow"),
+            image_url=image_url,
+            **common_kwargs,
+        )
+
+    return generate_base_image(
+        eyebrow=image_data.get("eyebrow"),
+        image_url=image_url,
+        **common_kwargs,
+    )
 
 
 def generate_base_image(
@@ -69,8 +163,9 @@ def generate_base_image(
     has_pro_subscription = check_if_profile_has_pro_subscription(profile_id)
     width, height = get_image_dimensions(site)
 
-    if image_url:
-        img = load_and_resize_image(image_url, width, height)
+    background_image = _load_optional_image(image_url, width, height)
+    if background_image is not None:
+        img = background_image
     else:
         img = Image.new("RGB", (width, height), color=(255, 255, 255))
 
@@ -79,7 +174,7 @@ def generate_base_image(
     img = Image.alpha_composite(img, overlay)
 
     draw = ImageDraw.Draw(img)
-    text_color = (255, 255, 255)  # Always use white text
+    text_color = (255, 255, 255)
 
     title_font = load_font(font, int(height * 0.1))
     subtitle_font = load_font(font, int(height * 0.05))
@@ -88,51 +183,53 @@ def generate_base_image(
     left_margin = int(width * 0.05)
     top_margin = int(height * 0.3)
     text_spacing = int(height * 0.02)
-
-    def draw_wrapped_text(text, font, max_width, y_position, is_title=False):
-        words = text.split()
-        lines = []
-        current_line = []
-
-        for word in words:
-            test_line = " ".join(current_line + [word])
-            bbox = font.getbbox(test_line)
-            if bbox[2] <= max_width:
-                current_line.append(word)
-            else:
-                lines.append(" ".join(current_line))
-                current_line = [word]
-
-        if current_line:
-            lines.append(" ".join(current_line))
-
-        for line in lines:
-            bbox = font.getbbox(line)
-            if is_title:
-                bold_offset = int(height * 0.002)
-                for offset_x in range(-bold_offset - 1, bold_offset + 1):
-                    for offset_y in range(-bold_offset, bold_offset + 1):
-                        draw.text((left_margin + offset_x, y_position + offset_y), line, font=font, fill=text_color)
-            else:
-                draw.text((left_margin, y_position), line, font=font, fill=text_color)
-            y_position += bbox[3] - bbox[1] + text_spacing
-        return y_position
-
-    current_y = top_margin
     max_text_width = width - 2 * left_margin
 
-    if eyebrow:
-        current_y = draw_wrapped_text(eyebrow.upper(), eyebrow_font, max_text_width, current_y)
+    normalized_title = _safe_truncate(title.upper() if title else "", 130)
+    normalized_subtitle = _safe_truncate(subtitle, 180)
+    normalized_eyebrow = _safe_truncate(eyebrow.upper() if eyebrow else "", 55)
+
+    current_y = top_margin
+
+    if normalized_eyebrow:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            normalized_eyebrow,
+            eyebrow_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+        )
         current_y += text_spacing
 
-    if title:
-        current_y = draw_wrapped_text(title.upper(), title_font, max_text_width, current_y, is_title=True)
-        current_y += text_spacing * 3.5
+    if normalized_title:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            normalized_title,
+            title_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+            is_title=True,
+            height=height,
+        )
+        current_y += int(text_spacing * 3.5)
 
-    if subtitle:
-        if len(subtitle) > 150:
-            subtitle = subtitle[:147] + "..."
-        draw_wrapped_text(subtitle, subtitle_font, max_text_width, current_y)
+    if normalized_subtitle:
+        _draw_wrapped_text_block(
+            draw,
+            normalized_subtitle,
+            subtitle_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+        )
 
     if not has_pro_subscription:
         add_watermark(img, draw, width, height)
@@ -163,31 +260,31 @@ def generate_logo_image(
     has_pro_subscription = check_if_profile_has_pro_subscription(profile_id)
     width, height = get_image_dimensions(site)
 
-    background_color = (30, 30, 30)  # Almost black
+    background_color = (30, 30, 30)
     img = Image.new("RGB", (width, height), color=background_color)
 
     draw = ImageDraw.Draw(img)
-    text_color = (255, 255, 255)  # White text
+    text_color = (255, 255, 255)
 
     title_font = load_font(font, int(height * 0.08))
     subtitle_font = load_font(font, int(height * 0.05))
 
     if image_url:
-        logo = load_and_resize_image(image_url, int(height * 0.4), int(height * 0.4))
-        logo = logo.convert("RGBA")
+        logo = _load_optional_image(image_url, int(height * 0.4), int(height * 0.4))
+        if logo is not None:
+            logo = logo.convert("RGBA")
 
-        mask = Image.new("L", logo.size, 0)
-        draw_mask = ImageDraw.Draw(mask)
-        draw_mask.ellipse((0, 0) + logo.size, fill=255)
+            mask = Image.new("L", logo.size, 0)
+            draw_mask = ImageDraw.Draw(mask)
+            draw_mask.ellipse((0, 0) + logo.size, fill=255)
 
-        logo = Image.composite(logo, Image.new("RGBA", logo.size, (0, 0, 0, 0)), mask)
+            logo = Image.composite(logo, Image.new("RGBA", logo.size, (0, 0, 0, 0)), mask)
 
-        logo_x = (width - logo.width) // 2
-        logo_y = int(height * 0.15)
+            logo_x = (width - logo.width) // 2
+            logo_y = int(height * 0.15)
 
-        img.paste(logo, (logo_x, logo_y), logo)
+            img.paste(logo, (logo_x, logo_y), logo)
 
-    # Calculate text positions and dimensions
     left_margin = int(width * 0.05)
     text_spacing = int(height * 0.02)
     max_text_width = width - 2 * left_margin
@@ -195,10 +292,12 @@ def generate_logo_image(
     title_y = int(height * 0.62)
     subtitle_y = int(height * 0.72)
 
-    # Draw title with text wrapping
+    normalized_title = _safe_truncate(title, 90)
+    normalized_subtitle = _safe_truncate(subtitle, 130)
+
     draw_wrapped_text(
         draw,
-        title,
+        normalized_title,
         title_font,
         max_text_width,
         title_y,
@@ -210,10 +309,302 @@ def generate_logo_image(
         height=height,
     )
 
-    # Draw subtitle with text wrapping
     draw_wrapped_text(
-        draw, subtitle, subtitle_font, max_text_width, subtitle_y, text_spacing, text_color, width, align="center"
+        draw,
+        normalized_subtitle,
+        subtitle_font,
+        max_text_width,
+        subtitle_y,
+        text_spacing,
+        text_color,
+        width,
+        align="center",
     )
+
+    if not has_pro_subscription:
+        add_watermark(img, draw, width, height)
+
+    return create_image_buffer(img, output_format=output_format, quality=quality, max_kb=max_kb)
+
+
+def generate_job_classic_image(
+    profile_id,
+    site,
+    font,
+    title,
+    subtitle,
+    eyebrow,
+    image_url,
+    output_format="png",
+    quality=None,
+    max_kb=None,
+):
+    has_pro_subscription = check_if_profile_has_pro_subscription(profile_id)
+    width, height = get_image_dimensions(site)
+
+    background_image = _load_optional_image(image_url, width, height)
+    if background_image is not None:
+        img = background_image.convert("RGBA")
+    else:
+        img = Image.new("RGBA", (width, height), color=(24, 32, 46, 255))
+
+    overlay = Image.new("RGBA", (width, height), (0, 0, 0, 130))
+    img = Image.alpha_composite(img, overlay)
+
+    draw = ImageDraw.Draw(img)
+
+    title, subtitle, eyebrow = _normalize_job_copy(title, subtitle, eyebrow)
+
+    title_font = load_font(font, int(height * 0.09))
+    subtitle_font = load_font(font, int(height * 0.05))
+    eyebrow_font = load_font(font, int(height * 0.032))
+
+    left_margin = int(width * 0.08)
+    current_y = int(height * 0.22)
+    max_text_width = int(width * 0.84)
+    text_spacing = int(height * 0.016)
+
+    text_color = (255, 255, 255)
+
+    if eyebrow:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            eyebrow.upper(),
+            eyebrow_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+        )
+        current_y += int(height * 0.02)
+
+    if title:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            title,
+            title_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+            is_title=True,
+            height=height,
+        )
+        current_y += int(height * 0.03)
+
+    if subtitle:
+        _draw_wrapped_text_block(
+            draw,
+            subtitle,
+            subtitle_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            text_color,
+            text_spacing,
+        )
+
+    if not has_pro_subscription:
+        add_watermark(img, draw, width, height)
+
+    return create_image_buffer(img, output_format=output_format, quality=quality, max_kb=max_kb)
+
+
+def generate_job_logo_image(
+    profile_id,
+    site,
+    font,
+    title,
+    subtitle,
+    eyebrow,
+    image_url,
+    output_format="png",
+    quality=None,
+    max_kb=None,
+):
+    has_pro_subscription = check_if_profile_has_pro_subscription(profile_id)
+    width, height = get_image_dimensions(site)
+
+    img = Image.new("RGB", (width, height), color=(17, 24, 39))
+    draw = ImageDraw.Draw(img)
+
+    title, subtitle, eyebrow = _normalize_job_copy(title, subtitle, eyebrow)
+
+    title_font = load_font(font, int(height * 0.085))
+    subtitle_font = load_font(font, int(height * 0.05))
+    eyebrow_font = load_font(font, int(height * 0.03))
+
+    left_margin = int(width * 0.08)
+    max_text_width = int(width * 0.6)
+    text_spacing = int(height * 0.016)
+    current_y = int(height * 0.2)
+
+    if eyebrow:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            eyebrow.upper(),
+            eyebrow_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            (147, 197, 253),
+            text_spacing,
+        )
+        current_y += int(height * 0.015)
+
+    if title:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            title,
+            title_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            (255, 255, 255),
+            text_spacing,
+            is_title=True,
+            height=height,
+        )
+        current_y += int(height * 0.02)
+
+    if subtitle:
+        _draw_wrapped_text_block(
+            draw,
+            subtitle,
+            subtitle_font,
+            max_text_width,
+            left_margin,
+            current_y,
+            (209, 213, 219),
+            text_spacing,
+        )
+
+    logo_size = int(height * 0.42)
+    logo_x = width - logo_size - int(width * 0.08)
+    logo_y = int(height * 0.15)
+
+    logo = _load_optional_image(image_url, logo_size, logo_size)
+    if logo is not None:
+        logo = logo.convert("RGBA")
+
+        mask = Image.new("L", logo.size, 0)
+        draw_mask = ImageDraw.Draw(mask)
+        draw_mask.ellipse((0, 0) + logo.size, fill=255)
+        logo = Image.composite(logo, Image.new("RGBA", logo.size, (0, 0, 0, 0)), mask)
+
+        img.paste(logo, (logo_x, logo_y), logo)
+    else:
+        placeholder_box = [
+            logo_x,
+            logo_y,
+            logo_x + logo_size,
+            logo_y + logo_size,
+        ]
+        draw.ellipse(placeholder_box, outline=(75, 85, 99), width=4)
+        draw.text(
+            (logo_x + int(logo_size * 0.24), logo_y + int(logo_size * 0.44)),
+            "LOGO",
+            fill=(107, 114, 128),
+            font=load_font(font, int(height * 0.03)),
+        )
+
+    if not has_pro_subscription:
+        add_watermark(img, draw, width, height)
+
+    return create_image_buffer(img, output_format=output_format, quality=quality, max_kb=max_kb)
+
+
+def generate_job_clean_image(
+    profile_id,
+    site,
+    font,
+    title,
+    subtitle,
+    eyebrow,
+    image_url,
+    output_format="png",
+    quality=None,
+    max_kb=None,
+):
+    has_pro_subscription = check_if_profile_has_pro_subscription(profile_id)
+    width, height = get_image_dimensions(site)
+
+    img = Image.new("RGB", (width, height), color=(250, 250, 252))
+    draw = ImageDraw.Draw(img)
+
+    title, subtitle, eyebrow = _normalize_job_copy(title, subtitle, eyebrow)
+
+    title_font = load_font(font, int(height * 0.082))
+    subtitle_font = load_font(font, int(height * 0.048))
+    eyebrow_font = load_font(font, int(height * 0.028))
+
+    accent_width = int(width * 0.018)
+    draw.rectangle([0, 0, accent_width, height], fill=(37, 99, 235))
+
+    content_left = accent_width + int(width * 0.06)
+    max_text_width = int(width * 0.62)
+    text_spacing = int(height * 0.014)
+    current_y = int(height * 0.22)
+
+    if eyebrow:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            eyebrow.upper(),
+            eyebrow_font,
+            max_text_width,
+            content_left,
+            current_y,
+            (37, 99, 235),
+            text_spacing,
+        )
+        current_y += int(height * 0.012)
+
+    if title:
+        current_y = _draw_wrapped_text_block(
+            draw,
+            title,
+            title_font,
+            max_text_width,
+            content_left,
+            current_y,
+            (17, 24, 39),
+            text_spacing,
+            is_title=True,
+            height=height,
+        )
+        current_y += int(height * 0.018)
+
+    if subtitle:
+        _draw_wrapped_text_block(
+            draw,
+            subtitle,
+            subtitle_font,
+            max_text_width,
+            content_left,
+            current_y,
+            (55, 65, 81),
+            text_spacing,
+        )
+
+    logo_size = int(height * 0.28)
+    logo_x = width - logo_size - int(width * 0.08)
+    logo_y = int(height * 0.34)
+    logo = _load_optional_image(image_url, logo_size, logo_size)
+    if logo is not None:
+        img.paste(logo.convert("RGB"), (logo_x, logo_y))
+    else:
+        draw.rectangle(
+            [
+                logo_x,
+                logo_y,
+                logo_x + logo_size,
+                logo_y + logo_size,
+            ],
+            outline=(209, 213, 219),
+            width=3,
+        )
 
     if not has_pro_subscription:
         add_watermark(img, draw, width, height)

--- a/core/views.py
+++ b/core/views.py
@@ -39,7 +39,13 @@ class HomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["site_choices"] = [("x", "X (Twitter)"), ("meta", "meta")]
-        context["style_choices"] = [("base", "Base"), ("logo", "Logo")]
+        context["style_choices"] = [
+            ("base", "Base"),
+            ("logo", "Logo"),
+            ("job_classic", "Job Classic"),
+            ("job_logo", "Job Logo"),
+            ("job_clean", "Job Clean"),
+        ]
         context["font_choices"] = [("helvetica", "Helvetica"), ("markerfelt", "Marker Felt"), ("papyrus", "Papyrus")]
 
         if self.request.user.is_authenticated:
@@ -256,6 +262,8 @@ def generate_image(request):
     quality = _normalize_quality(request.GET.get("quality"), output_format)
     max_kb = _normalize_max_kb(request.GET.get("max_kb"))
 
+    image_url = request.GET.get("image_url") or request.GET.get("image_or_logo")
+
     params = {
         "key": request.GET.get("key", ""),
         "style": request.GET.get("style", "base"),
@@ -264,7 +272,7 @@ def generate_image(request):
         "title": request.GET.get("title"),
         "subtitle": request.GET.get("subtitle"),
         "eyebrow": request.GET.get("eyebrow"),
-        "image_url": request.GET.get("image_url"),
+        "image_url": image_url,
     }
 
     if output_format != "png":

--- a/docs/job-board-template-pack-v1.md
+++ b/docs/job-board-template-pack-v1.md
@@ -1,0 +1,36 @@
+# Job-board Template Pack v1
+
+Wave 1 task [4/8] introduces three templates tuned for job board listings and role previews.
+
+## Styles
+
+- `job_classic`: image-first, dark overlay, high-contrast text
+- `job_logo`: text + circular logo emphasis
+- `job_clean`: minimal white layout with accent bar
+
+## Supported fields
+
+All templates accept:
+
+- `title`
+- `subtitle`
+- `eyebrow`
+- `image_or_logo` (alias for `image_url`)
+
+Existing `/g` flows remain backward compatible (`base`/`logo` still unchanged).
+
+## Safe truncation
+
+Long text is normalized and truncated before render:
+
+- title: 110 chars
+- subtitle: 180 chars
+- eyebrow: 55 chars
+
+This prevents overflow while keeping output deterministic for caching.
+
+## Example URL
+
+```text
+/g?style=job_logo&site=x&title=Senior%20Django%20Engineer&subtitle=Ship%20production%20systems&eyebrow=Remote&image_or_logo=https://example.com/logo.png
+```


### PR DESCRIPTION
## Summary
- add Wave 1 job-board template pack v1 with three new styles: `job_classic`, `job_logo`, and `job_clean`
- keep `/g` backward-compatible for existing `base` and `logo` styles while adding `image_or_logo` alias support
- add safe copy truncation/normalization guards for long `title`, `subtitle`, and `eyebrow` values in job templates
- expose new templates in home UI style selector
- document template pack usage in README and `docs/job-board-template-pack-v1.md`

## Testing
- `ENVIRONMENT=dev SECRET_KEY=test-secret DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1,testserver CSRF_TRUSTED_ORIGINS=http://localhost DATABASE_URL=sqlite:////tmp/osig-test.db AWS_S3_ENDPOINT_URL=http://localhost AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test REDIS_URL=redis://localhost:6379/0 GITHUB_CLIENT_ID=dummy GITHUB_CLIENT_SECRET=dummy MAILGUN_API_KEY=dummy BUTTONDOWN_API_KEY=dummy POSTHOG_API_KEY=dummy STRIPE_LIVE_SECRET_KEY=sk_test STRIPE_TEST_SECRET_KEY=sk_test DJSTRIPE_WEBHOOK_SECRET=whsec_test .venv/bin/python -m pytest core/tests/test_generate_image_features.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three job-board template styles: Classic, Logo, and Clean for diverse hiring-focused designs.
  * Introduced `image_or_logo` parameter alias for flexible asset handling in job-board templates.

* **Documentation**
  * Added comprehensive job-board template documentation with usage examples and safe text truncation guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->