### PR TITLE
feat(osig): add onboarding wizard for OG meta generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,49 @@ Social preview refresh checklist:
 - Re-deploy metadata with the new URL
 - Re-validate on social debuggers (X Card Validator / LinkedIn Post Inspector / Facebook Sharing Debugger)
 
+### 4) Onboarding wizard helper
+
+`GET /onboarding` now exposes a 5-step guided wizard that outputs:
+
+- signed OG image URL (reuses `POST /api/sign`)
+- copy-ready OG/Twitter meta tags
+- validation links (X/Twitter, Facebook, LinkedIn, Google rich results)
+
+Backend helper endpoint used by the wizard:
+
+`POST /api/onboarding/meta`
+
+Example:
+
+```json
+{
+  "page_url": "https://example.com/jobs/senior-engineer",
+  "style": "job_logo",
+  "site": "x",
+  "font": "helvetica",
+  "title": "Senior Engineer",
+  "subtitle": "Ship reliable backend systems",
+  "eyebrow": "Remote · Full-time",
+  "image_url": "https://example.com/logo.png",
+  "format": "jpeg",
+  "quality": 80,
+  "version": "v2026-02-26"
+}
+```
+
+Response:
+
+```json
+{
+  "signed_url": "https://osig.app/g?...&exp=...&sig=...",
+  "expires_at": "2026-02-26T12:34:56+00:00",
+  "meta_tags": "<meta ... />\n<meta ... />",
+  "validation_links": {
+    "Twitter/X Card Validator": "https://cards-dev.twitter.com/validator?url=..."
+  }
+}
+```
+
 ## Roadmap
 
 - Add instruction on how to self host.

--- a/core/api/schemas.py
+++ b/core/api/schemas.py
@@ -27,3 +27,26 @@ class SignOgUrlIn(Schema):
 class SignOgUrlOut(Schema):
     signed_url: str
     expires_at: str
+
+
+class OnboardingWizardIn(Schema):
+    page_url: str = "https://osig.app"
+    style: str = "base"
+    site: str = "x"
+    font: str = "helvetica"
+    title: str = ""
+    subtitle: str = ""
+    eyebrow: str = ""
+    image_url: str = ""
+    format: str = "png"
+    quality: str | int | None = None
+    max_kb: str | int | None = None
+    version: str = ""
+    expires_in_seconds: int = 3600
+
+
+class OnboardingWizardOut(Schema):
+    signed_url: str
+    expires_at: str
+    meta_tags: str
+    validation_links: dict[str, str]

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -1,11 +1,12 @@
-from urllib.parse import urlencode
+from html import escape
+from urllib.parse import quote_plus, urlencode
 
 from django.http import HttpRequest
 from django.urls import reverse
 from ninja import NinjaAPI
 
 from core.api.auth import superuser_api_auth
-from core.api.schemas import BlogPostIn, BlogPostOut, SignOgUrlIn, SignOgUrlOut
+from core.api.schemas import BlogPostIn, BlogPostOut, OnboardingWizardIn, OnboardingWizardOut, SignOgUrlIn, SignOgUrlOut
 from core.models import BlogPost
 from core.signing import build_signed_params
 
@@ -29,6 +30,81 @@ def submit_blog_post(request: HttpRequest, data: BlogPostIn):
         return BlogPostOut(status="error", message=f"Failed to submit blog post: {str(e)}")
 
 
+def _build_onboarding_cache_key(version: str) -> str:
+    return version.strip()
+
+
+def _to_int_if_valid(value: str | int | None) -> int | None:
+    if value in (None, ""):
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_onboarding_params(data: OnboardingWizardIn) -> dict:
+    params = {
+        "style": data.style,
+        "site": data.site,
+        "font": data.font,
+        "title": data.title,
+        "subtitle": data.subtitle,
+        "eyebrow": data.eyebrow,
+        "format": data.format,
+    }
+
+    quality = _to_int_if_valid(data.quality)
+    if quality is not None:
+        params["quality"] = quality
+
+    max_kb = _to_int_if_valid(data.max_kb)
+    if max_kb is not None:
+        params["max_kb"] = max_kb
+
+    version = _build_onboarding_cache_key(data.version)
+    if version:
+        params["v"] = version
+
+    if data.image_url:
+        params["image_url"] = data.image_url
+
+    return params
+
+
+def _build_validation_links(page_url: str) -> dict[str, str]:
+    encoded_url = quote_plus(page_url)
+    return {
+        "Twitter/X Card Validator": f"https://cards-dev.twitter.com/validator?url={encoded_url}",
+        "Facebook Sharing Debugger": f"https://developers.facebook.com/tools/debug/?q={encoded_url}",
+        "LinkedIn Post Inspector": f"https://www.linkedin.com/post-inspector/inspect/{encoded_url}",
+        "Google Rich Results": f"https://search.google.com/test/rich-results?url={encoded_url}",
+    }
+
+
+def _build_meta_tags(signed_url: str, title: str, subtitle: str, page_url: str) -> str:
+    escaped_title = escape(title, quote=True)
+    escaped_subtitle = escape(subtitle, quote=True)
+    escaped_page_url = escape(page_url, quote=True)
+    escaped_image = escape(signed_url, quote=True)
+
+    return "\n".join(
+        [
+            f'<meta property="og:type" content="website" />',
+            f'<meta property="og:title" content="{escaped_title}" />',
+            f'<meta property="og:description" content="{escaped_subtitle}" />',
+            f'<meta property="og:url" content="{escaped_page_url}" />',
+            f'<meta property="og:image" content="{escaped_image}" />',
+            f'<meta name="twitter:card" content="summary_large_image" />',
+            f'<meta name="twitter:title" content="{escaped_title}" />',
+            f'<meta name="twitter:description" content="{escaped_subtitle}" />',
+            f'<meta name="twitter:image" content="{escaped_image}" />',
+            f'<meta property="og:image:alt" content="{escaped_title}" />',
+        ]
+    )
+
+
 @api.post("/sign", response=SignOgUrlOut)
 def sign_og_url(request: HttpRequest, data: SignOgUrlIn):
     base_url = request.build_absolute_uri(reverse("generate_image"))
@@ -43,4 +119,20 @@ def sign_og_url(request: HttpRequest, data: SignOgUrlIn):
     return SignOgUrlOut(
         signed_url=signed_url,
         expires_at=expires_at.isoformat(),
+    )
+
+
+@api.post("/onboarding/meta", response=OnboardingWizardOut)
+def build_onboarding_meta_tags(request: HttpRequest, data: OnboardingWizardIn):
+    base_url = request.build_absolute_uri(reverse("generate_image"))
+    params = _build_onboarding_params(data)
+
+    signed_params, expires_at = build_signed_params(params=params, expires_in_seconds=data.expires_in_seconds)
+    signed_url = f"{base_url}?{urlencode(signed_params)}"
+
+    return OnboardingWizardOut(
+        signed_url=signed_url,
+        expires_at=expires_at.isoformat(),
+        meta_tags=_build_meta_tags(signed_url=signed_url, title=data.title, subtitle=data.subtitle, page_url=data.page_url),
+        validation_links=_build_validation_links(data.page_url),
     )

--- a/core/tests/test_onboarding_wizard.py
+++ b/core/tests/test_onboarding_wizard.py
@@ -1,0 +1,49 @@
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestOnboardingWizardAPI:
+    def test_onboarding_api_generates_signed_og_meta_and_checks(self, client):
+        payload = {
+            "page_url": "https://example.com/jobs/senior-engineer",
+            "style": "job_logo",
+            "site": "x",
+            "font": "helvetica",
+            "title": "Senior Engineering Lead",
+            "subtitle": "Build and ship resilient systems",
+            "eyebrow": "Remote",
+            "image_url": "https://example.com/logo.png",
+            "format": "jpeg",
+            "quality": 80,
+            "version": "v2026",
+            "expires_in_seconds": 600,
+        }
+
+        response = client.post(
+            "/api/onboarding/meta",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["signed_url"].startswith("http")
+        parsed = parse_qs(urlparse(data["signed_url"]).query)
+
+        assert parsed["style"] == ["job_logo"]
+        assert parsed["site"] == ["x"]
+        assert parsed["format"] == ["jpeg"]
+        assert parsed["quality"] == ["80"]
+        assert parsed["v"] == ["v2026"]
+        assert "sig" in parsed
+        assert "exp" in parsed
+
+        assert "<meta property=\"og:title\"" in data["meta_tags"]
+        assert "twitter:image" in data["meta_tags"]
+        assert data["validation_links"]["Facebook Sharing Debugger"].startswith(
+            "https://developers.facebook.com/tools/debug/"
+        )

--- a/core/urls.py
+++ b/core/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
     path("settings", views.UserSettingsView.as_view(), name="settings"),
     path("how-to", views.HowToView.as_view(), name="how_to"),
+    path("onboarding", views.OnboardingWizardView.as_view(), name="onboarding_wizard"),
     # api
     path("api/", api.urls),
     # blog

--- a/core/views.py
+++ b/core/views.py
@@ -89,6 +89,10 @@ class HowToView(TemplateView):
     template_name = "pages/how-to.html"
 
 
+class OnboardingWizardView(TemplateView):
+    template_name = "pages/onboarding-wizard.html"
+
+
 class BlogView(ListView):
     model = BlogPost
     template_name = "blog/blog_posts.html"

--- a/docs/onboarding-wizard.md
+++ b/docs/onboarding-wizard.md
@@ -1,0 +1,32 @@
+# OSIG Onboarding Wizard
+
+Wave 1 task [5/8] adds a guided onboarding flow for generating OG metadata quickly.
+
+## What it does
+
+- 5-step guided wizard available at `/onboarding`.
+- Builds signed OG image URL via `/api/onboarding/meta`.
+- Outputs ready-to-copy OG/Twitter meta tags.
+- Generates validation checklist links:
+  - Twitter/X Card Validator
+  - Facebook Sharing Debugger
+  - LinkedIn Post Inspector
+  - Google Rich Results
+- Keeps legacy behavior unchanged:
+  - `/g` still accepts legacy style inputs.
+  - image URL handling preserves `image_url` and `image_or_logo` compatibility.
+
+## Output shape
+
+`POST /api/onboarding/meta` returns:
+
+- `signed_url`
+- `expires_at`
+- `meta_tags` (preformatted HTML tags)
+- `validation_links` (map of label -> URL)
+
+## Notes
+
+- Quality is optional and only used for JPEG.
+- `version` maps to the existing `v` cache-busting query param.
+- `expires_in_seconds` defaults to 3600 if omitted.

--- a/frontend/src/controllers/onboarding_wizard_controller.js
+++ b/frontend/src/controllers/onboarding_wizard_controller.js
@@ -1,0 +1,185 @@
+import { Controller } from "@hotwired/stimulus";
+
+const FORM_STEP_COUNT = 5;
+
+export default class extends Controller {
+  static targets = [
+    "step",
+    "pageUrl",
+    "title",
+    "subtitle",
+    "eyebrow",
+    "site",
+    "style",
+    "font",
+    "imageUrl",
+    "format",
+    "quality",
+    "maxKb",
+    "version",
+    "metaTags",
+    "validationLinks",
+    "previewLink",
+    "errorMessage",
+    "wizardForm",
+  ];
+
+  connect() {
+    this.currentStep = 0;
+    this.updateStepVisibility();
+    if (this.hasPageUrlTarget) {
+      this.pageUrlTarget.value = `${window.location.origin}`;
+    }
+  }
+
+  goNext() {
+    if (this.currentStep < FORM_STEP_COUNT - 1) {
+      this.currentStep += 1;
+      this.updateStepVisibility();
+    }
+  }
+
+  goPrevious() {
+    if (this.currentStep > 0) {
+      this.currentStep -= 1;
+      this.updateStepVisibility();
+    }
+  }
+
+  updateStepVisibility() {
+    this.stepTargets.forEach((step, index) => {
+      step.classList.toggle("hidden", index !== this.currentStep);
+    });
+
+    if (this.errorMessageTarget) {
+      this.errorMessageTarget.textContent = "";
+    }
+  }
+
+  async generate(event) {
+    event.preventDefault();
+    this.clearError();
+    this.disableButtons(true);
+
+    try {
+      const payload = this.buildPayload();
+
+      const response = await fetch("/api/onboarding/meta", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || "Unable to generate onboarding artifacts.");
+      }
+
+      const data = await response.json();
+      this.metaTagsTarget.value = data.meta_tags;
+      this.previewLinkTarget.href = data.signed_url;
+      this.renderValidationLinks(data.validation_links);
+    } catch (error) {
+      this.setError(error.message || "Unable to generate onboarding artifacts.");
+    } finally {
+      this.disableButtons(false);
+    }
+  }
+
+  async copyMetaTags() {
+    try {
+      await navigator.clipboard.writeText(this.metaTagsTarget.value);
+    } catch (error) {
+      this.setError("Failed to copy meta tags.");
+      console.error("Failed to copy meta tags", error);
+    }
+  }
+
+  reset() {
+    this.wizardFormTarget.reset();
+    this.currentStep = 0;
+    this.metaTagsTarget.value = "";
+    this.previewLinkTarget.href = "#";
+    this.validationLinksTarget.innerHTML = "";
+    this.clearError();
+    this.updateStepVisibility();
+  }
+
+  buildPayload() {
+    if (!this.pageUrlTarget.value.trim()) {
+      throw new Error("Please provide a canonical page URL.");
+    }
+
+    if (!this.titleTarget.value.trim()) {
+      throw new Error("Please provide a title.");
+    }
+
+    const qualityValue = Number.parseInt(this.qualityTarget.value, 10);
+
+    const payload = {
+      page_url: this.pageUrlTarget.value.trim(),
+      style: this.styleTarget.value,
+      site: this.siteTarget.value,
+      font: this.fontTarget.value,
+      title: this.titleTarget.value.trim(),
+      subtitle: this.subtitleTarget.value.trim(),
+      eyebrow: this.eyebrowTarget.value.trim(),
+      image_url: this.imageUrlTarget.value.trim(),
+      format: this.formatTarget.value,
+      version: this.versionTarget.value.trim(),
+      expires_in_seconds: 3600,
+    };
+
+    const maxKbValue = Number.parseInt(this.maxKbTarget.value, 10);
+
+    if (Number.isInteger(qualityValue) && qualityValue > 0 && qualityValue <= 100) {
+      payload.quality = qualityValue;
+    }
+
+    if (Number.isInteger(maxKbValue) && maxKbValue > 0) {
+      payload.max_kb = maxKbValue;
+    }
+
+    return payload;
+  }
+
+  renderValidationLinks(validationLinks) {
+    this.validationLinksTarget.innerHTML = "";
+
+    Object.entries(validationLinks).forEach(([name, href]) => {
+      const link = document.createElement("a");
+      link.href = href;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.className = "inline-block mr-3 text-sm text-blue-600 underline";
+      link.textContent = name;
+
+      const wrapper = document.createElement("div");
+      wrapper.appendChild(link);
+      this.validationLinksTarget.appendChild(wrapper);
+    });
+  }
+
+  setError(message) {
+    if (this.hasErrorMessageTarget) {
+      this.errorMessageTarget.textContent = message;
+    }
+  }
+
+  clearError() {
+    if (this.hasErrorMessageTarget) {
+      this.errorMessageTarget.textContent = "";
+    }
+  }
+
+  disableButtons(disabled) {
+    this.stepTargets.forEach((step) => {
+      step.querySelectorAll("button").forEach((button) => {
+        button.disabled = disabled;
+        button.classList.toggle("opacity-50", disabled);
+      });
+    });
+  }
+}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -98,6 +98,9 @@
                       <a href="{% url 'how_to' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
                         How to use?
                       </a>
+                      <a href="{% url 'onboarding_wizard' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
+                        Onboarding
+                      </a>
                       <a href="{% url 'blog_posts' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
                         Blog
                       </a>
@@ -183,6 +186,9 @@
           <div class="flex items-center space-x-8">
             <a href="{% url 'how_to' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
               How to use?
+            </a>
+            <a href="{% url 'onboarding_wizard' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
+              Onboarding
             </a>
             <a href="{% url 'blog_posts' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
               Blog

--- a/frontend/templates/pages/onboarding-wizard.html
+++ b/frontend/templates/pages/onboarding-wizard.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+{% load webpack_loader static %}
+
+{% block content %}
+<div class="container px-4 py-8 mx-auto">
+  <div class="mx-auto max-w-3xl" data-controller="onboarding-wizard">
+    <h1 class="mb-3 text-3xl font-bold text-center">OG Image Onboarding Wizard</h1>
+    <p class="mb-8 text-center text-gray-600">Go from blank form to publish-ready OG meta tags in 5 steps.</p>
+
+    <form data-onboarding-wizard-target="wizardForm" class="space-y-6" novalidate>
+      <section data-onboarding-wizard-target="step" class="space-y-4">
+        <h2 class="text-xl font-semibold">Step 1 · Content destination</h2>
+        <div>
+          <label for="page_url" class="block mb-1 text-sm font-medium text-gray-700">Canonical page URL</label>
+          <input id="page_url" data-onboarding-wizard-target="pageUrl" type="url" placeholder="https://example.com/job-offer" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+        </div>
+        <div class="flex justify-end">
+          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        </div>
+      </section>
+
+      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
+        <h2 class="text-xl font-semibold">Step 2 · Core OG copy</h2>
+        <div>
+          <label for="title" class="block mb-1 text-sm font-medium text-gray-700">Title</label>
+          <input id="title" data-onboarding-wizard-target="title" type="text" placeholder="Hiring: Senior Backend Engineer" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+        </div>
+        <div>
+          <label for="subtitle" class="block mb-1 text-sm font-medium text-gray-700">Subtitle</label>
+          <textarea id="subtitle" data-onboarding-wizard-target="subtitle" rows="3" placeholder="Build reliable services with Django + Postgres." class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"></textarea>
+        </div>
+        <div>
+          <label for="eyebrow" class="block mb-1 text-sm font-medium text-gray-700">Eyebrow</label>
+          <input id="eyebrow" data-onboarding-wizard-target="eyebrow" type="text" placeholder="Remote · Full-time" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+        </div>
+        <div class="flex justify-between">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        </div>
+      </section>
+
+      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
+        <h2 class="text-xl font-semibold">Step 3 · Image & template</h2>
+        <div>
+          <label for="site" class="block mb-1 text-sm font-medium text-gray-700">Social image size</label>
+          <select id="site" data-onboarding-wizard-target="site" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+            <option value="x">X / Twitter (1600 x 900)</option>
+            <option value="meta">Meta (1200 x 630)</option>
+          </select>
+        </div>
+        <div>
+          <label for="style" class="block mb-1 text-sm font-medium text-gray-700">Style</label>
+          <select id="style" data-onboarding-wizard-target="style" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+            <option value="base">Base</option>
+            <option value="logo">Logo</option>
+            <option value="job_classic">Job Classic</option>
+            <option value="job_logo">Job Logo</option>
+            <option value="job_clean">Job Clean</option>
+          </select>
+        </div>
+        <div>
+          <label for="font" class="block mb-1 text-sm font-medium text-gray-700">Font</label>
+          <select id="font" data-onboarding-wizard-target="font" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+            <option value="helvetica">Helvetica</option>
+            <option value="markerfelt">Marker Felt</option>
+            <option value="papyrus">Papyrus</option>
+          </select>
+        </div>
+        <div>
+          <label for="image_url" class="block mb-1 text-sm font-medium text-gray-700">Image / logo URL</label>
+          <input id="image_url" data-onboarding-wizard-target="imageUrl" type="url" placeholder="https://example.com/logo-or-cover.png" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <p class="mt-1 text-sm text-gray-500">For job styles you can pass a logo or brand image in this field.</p>
+        </div>
+        <div class="flex justify-between">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        </div>
+      </section>
+
+      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
+        <h2 class="text-xl font-semibold">Step 4 · Output controls</h2>
+        <div>
+          <label for="format" class="block mb-1 text-sm font-medium text-gray-700">Output format</label>
+          <select id="format" data-onboarding-wizard-target="format" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+            <option value="png">PNG</option>
+            <option value="jpeg">JPEG</option>
+          </select>
+        </div>
+        <div>
+          <label for="quality" class="block mb-1 text-sm font-medium text-gray-700">JPEG quality (1-100)</label>
+          <input id="quality" data-onboarding-wizard-target="quality" type="number" min="1" max="100" placeholder="85" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <p class="mt-1 text-sm text-gray-500">Only used when format = JPEG. Leave blank to use default quality.</p>
+        </div>
+        <div>
+          <label for="max_kb" class="block mb-1 text-sm font-medium text-gray-700">Max KB (optional)</label>
+          <input id="max_kb" data-onboarding-wizard-target="maxKb" type="number" min="1" placeholder="0" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <p class="mt-1 text-sm text-gray-500">Optional size target for signed image generation.</p>
+        </div>
+        <div>
+          <label for="version" class="block mb-1 text-sm font-medium text-gray-700">Cache version</label>
+          <input id="version" data-onboarding-wizard-target="version" type="text" placeholder="e.g. v2026" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <p class="mt-1 text-sm text-gray-500">Update this value when source content changes to bust cached image URLs.</p>
+        </div>
+        <div class="flex justify-between">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        </div>
+      </section>
+
+      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
+        <h2 class="text-xl font-semibold">Step 5 · Generate</h2>
+        <p class="text-sm text-gray-600">Sign your image URL, get ready-to-copy OG tags, and open validator links.</p>
+
+        <button type="button" data-action="onboarding-wizard#generate" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Generate OG meta</button>
+
+        <div class="mt-2">
+          <label for="meta_tags" class="block mb-1 text-sm font-medium text-gray-700">Copy-ready meta tags</label>
+          <textarea id="meta_tags" data-onboarding-wizard-target="metaTags" rows="12" readonly class="px-3 py-2 w-full rounded-md border border-gray-200 bg-gray-50 font-mono text-sm" placeholder="Generated tags will appear here"></textarea>
+          <div class="mt-3 flex gap-2">
+            <button type="button" data-action="onboarding-wizard#copyMetaTags" class="px-4 py-2 text-white bg-gray-800 rounded-md hover:bg-gray-900">Copy</button>
+            <a href="#" data-onboarding-wizard-target="previewLink" target="_blank" rel="noopener" class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100">Preview image</a>
+          </div>
+        </div>
+
+        <div>
+          <h3 class="mb-2 text-sm font-semibold text-gray-700">Validation checklist</h3>
+          <div data-onboarding-wizard-target="validationLinks" class="space-y-2"></div>
+        </div>
+
+        <p data-onboarding-wizard-target="errorMessage" class="text-sm text-red-600"></p>
+
+        <div class="flex justify-between">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
+          <button type="button" data-action="onboarding-wizard#reset" class="px-4 py-2 text-white bg-red-600 rounded-md hover:bg-red-700">Start over</button>
+        </div>
+      </section>
+    </form>
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Summary
- Added `/onboarding` wizard page (5-step flow) for guided OG metadata generation.
- Wizard captures destination URL, core OG copy, template/style/font image settings, and output controls.
- New API endpoint `POST /api/onboarding/meta` reuses existing signed URL primitives from `/api/sign` plus format/quality/max_kb/version handling.
- Endpoint returns ready-to-copy OG/Twitter meta tags and checklist links (Twitter/X, Facebook, LinkedIn, Google Rich Results).
- Added nav links from main header to `/onboarding`.
- Added backend tests for onboarding API payload/signing + validation links and new documentation for the wizard.

## Files
- `core/api/schemas.py`
- `core/api/views.py`
- `core/urls.py`
- `core/views.py`
- `frontend/templates/base.html`
- `frontend/templates/pages/onboarding-wizard.html`
- `frontend/src/controllers/onboarding_wizard_controller.js`
- `core/tests/test_onboarding_wizard.py`
- `README.md`
- `docs/onboarding-wizard.md`

## Testing
- `ENVIRONMENT=dev SECRET_KEY=test-secret DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1,testserver CSRF_TRUSTED_ORIGINS=http://localhost DATABASE_URL=sqlite:////tmp/osig-test.db AWS_S3_ENDPOINT_URL=http://localhost AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test REDIS_URL=redis://localhost:6379/0 GITHUB_CLIENT_ID=dummy GITHUB_CLIENT_SECRET=dummy MAILGUN_API_KEY=dummy BUTTONDOWN_API_KEY=dummy POSTHOG_API_KEY=dummy STRIPE_LIVE_SECRET_KEY=sk_test STRIPE_TEST_SECRET_KEY=sk_test DJSTRIPE_WEBHOOK_SECRET=whsec_test .venv/bin/python -m pytest core/tests/test_generate_image_features.py core/tests/test_onboarding_wizard.py -q`

## Blockers
- No functional blockers.
- Front-end behavior has been implemented client-side and exercised via endpoint tests; no browser automation added in this round.
