### PR TITLE
feat(osig): add WordPress helper MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,27 @@ Example response:
 }
 ```
 
+### 7) WordPress helper MVP
+
+`POST /api/integrations/wordpress` maps common WordPress fields to OSIG params and returns a ready signed URL.
+
+- maps `post_title`, `post_name`, `excerpt/description`, `featured_image_url/featured_image/logo`
+- supports `quality`, `max_kb`, `version` and cache-friendly URL parameters
+- applies image fallback chain:
+  1. `featured_image_url`
+  2. `featured_image`
+  3. `logo_url`
+  4. `fallback_image_url`
+  5. no image fallback
+
+Returns:
+
+- `signed_url`
+- `expires_at`
+- `mapped_fields`
+- `fallbacks`
+- `snippet` (PHP helper sample)
+
 ## Roadmap
 
 - Add instruction on how to self host.

--- a/core/api/schemas.py
+++ b/core/api/schemas.py
@@ -59,3 +59,36 @@ class RenderMetricsOut(Schema):
     fail_rate_percent: float
     p95_render_ms: int | None
     error_counts: dict[str, int]
+
+
+class WordPressHelperIn(Schema):
+    page_url: str
+    post_title: str = ""
+    post_name: str = ""
+    seo_title: str = ""
+    title: str = ""
+    subtitle: str = ""
+    excerpt: str = ""
+    description: str = ""
+    featured_image: str = ""
+    featured_image_url: str = ""
+    logo_url: str = ""
+    fallback_image_url: str = ""
+    eyebrow: str = ""
+    style: str = "job_logo"
+    site: str = "x"
+    font: str = "helvetica"
+    key: str = ""
+    format: str = "png"
+    quality: str | int | None = None
+    max_kb: str | int | None = None
+    version: str = ""
+    expires_in_seconds: int = 3600
+
+
+class WordPressHelperOut(Schema):
+    signed_url: str
+    expires_at: str
+    mapped_fields: dict[str, str]
+    fallbacks: list[str]
+    snippet: str

--- a/core/tests/test_wordpress_helper.py
+++ b/core/tests/test_wordpress_helper.py
@@ -1,0 +1,111 @@
+from urllib.parse import parse_qs, urlparse
+
+import json
+import pytest
+
+
+def _endpoint_payload():
+    return {
+        "page_url": "https://example.com/jobs/senior-engineer",
+        "post_title": "Senior PHP Engineer",
+        "post_name": "senior-php-engineer",
+        "subtitle": "Build backend services",
+        "excerpt": "",
+        "description": "",
+        "featured_image_url": "https://example.com/logo.png",
+        "logo_url": "",
+        "fallback_image_url": "https://example.com/fallback.png",
+        "style": "job_logo",
+        "site": "x",
+        "font": "helvetica",
+        "format": "jpeg",
+        "quality": 88,
+        "version": "v2026-02-26",
+        "eyebrow": "Remote · Full-time",
+        "key": "abc",
+    }
+
+
+@pytest.mark.django_db
+class TestWordPressHelper:
+    def test_wordpress_helper_maps_post_fields_and_signs_url(self, client):
+        response = client.post(
+            "/api/integrations/wordpress",
+            data=json.dumps(_endpoint_payload()),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+
+        assert payload["mapped_fields"]["title"] == "Senior PHP Engineer"
+        assert payload["mapped_fields"]["subtitle"] == "Build backend services"
+        assert payload["mapped_fields"]["image_url"] == "https://example.com/logo.png"
+        assert payload["mapped_fields"]["style"] == "job_logo"
+
+        parsed = parse_qs(urlparse(payload["signed_url"]).query)
+        assert parsed["title"] == ["Senior PHP Engineer"]
+        assert parsed["subtitle"] == ["Build backend services"]
+        assert parsed["style"] == ["job_logo"]
+        assert parsed["format"] == ["jpeg"]
+        assert parsed["quality"] == ["88"]
+        assert parsed["v"] == ["v2026-02-26"]
+        assert "sig" in parsed
+        assert "exp" in parsed
+
+        assert payload["snippet"].startswith("<?php")
+
+    def test_wordpress_helper_fallback_to_logo_when_no_featured_image(self, client):
+        payload = _endpoint_payload()
+        payload["featured_image_url"] = ""
+        payload["logo_url"] = "https://example.com/company-logo.png"
+
+        response = client.post(
+            "/api/integrations/wordpress",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["mapped_fields"]["image_url"] == "https://example.com/company-logo.png"
+        assert "image_fallback" not in data["fallbacks"]
+
+    def test_wordpress_helper_uses_fallback_image_when_no_logo_or_featured(self, client):
+        payload = _endpoint_payload()
+        payload["featured_image_url"] = ""
+        payload["logo_url"] = ""
+
+        response = client.post(
+            "/api/integrations/wordpress",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["mapped_fields"]["image_url"] == payload["fallback_image_url"]
+        assert data["fallbacks"] == ["image_fallback"]
+
+    def test_wordpress_helper_uses_slug_title_when_title_missing(self, client):
+        payload = {
+            "page_url": "https://example.com/jobs/senior-data-scientist",
+            "post_name": "senior-data-scientist",
+            "description": "Build ML systems",
+            "fallback_image_url": "https://example.com/fallback.png",
+            "style": "job_clean",
+        }
+
+        response = client.post(
+            "/api/integrations/wordpress",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mapped_fields"]["title"] == "Senior Data Scientist"
+        assert data["mapped_fields"]["subtitle"] == "Build ML systems"
+        assert data["mapped_fields"]["image_url"] == payload["fallback_image_url"]

--- a/core/wordpress_helper.py
+++ b/core/wordpress_helper.py
@@ -1,0 +1,155 @@
+from dataclasses import dataclass
+
+
+def _to_int_if_valid(value: str | int | None) -> int | None:
+    if value in (None, ""):
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class WordPressRenderResult:
+    params: dict
+    mapped_fields: dict[str, str]
+    fallbacks: list[str]
+
+
+def _first_non_empty(*values: str) -> str:
+    for value in values:
+        normalized = (value or "").strip()
+        if normalized:
+            return normalized
+    return ""
+
+
+def _slug_to_title(slug: str) -> str:
+    normalized = (slug or "").strip()
+    if not normalized:
+        return ""
+
+    return normalized.replace("-", " ").replace("_", " ").title()
+
+
+def build_wordpress_render_params(
+    *,
+    page_url: str,
+    post_title: str = "",
+    post_name: str = "",
+    seo_title: str = "",
+    title: str = "",
+    subtitle: str = "",
+    excerpt: str = "",
+    description: str = "",
+    featured_image: str = "",
+    featured_image_url: str = "",
+    logo_url: str = "",
+    fallback_image_url: str = "",
+    eyebrow: str = "",
+    style: str = "job_logo",
+    site: str = "x",
+    font: str = "helvetica",
+    key: str = "",
+    format: str = "png",
+    quality: str | int | None = None,
+    max_kb: str | int | None = None,
+    version: str = "",
+) -> WordPressRenderResult:
+    if not page_url:
+        raise ValueError("page_url is required")
+
+    mapped_title = _first_non_empty(title, post_title, seo_title, _slug_to_title(post_name))
+    mapped_subtitle = _first_non_empty(subtitle, excerpt, description)
+
+    image_url = _first_non_empty(featured_image_url, featured_image, logo_url)
+    fallbacks: list[str] = []
+
+    if not image_url:
+        if fallback_image_url:
+            image_url = fallback_image_url.strip()
+            fallbacks.append("image_fallback")
+        else:
+            fallbacks.append("image_missing")
+
+    params = {
+        "style": style or "job_logo",
+        "site": site or "x",
+        "font": font or "helvetica",
+        "title": mapped_title,
+        "subtitle": mapped_subtitle,
+        "eyebrow": eyebrow,
+        "format": format or "png",
+        "key": key,
+    }
+
+    if key:
+        params["key"] = key
+    if image_url:
+        params["image_url"] = image_url
+
+    normalized_quality = _to_int_if_valid(quality)
+    if normalized_quality is not None:
+        params["quality"] = normalized_quality
+
+    normalized_max_kb = _to_int_if_valid(max_kb)
+    if normalized_max_kb is not None:
+        params["max_kb"] = normalized_max_kb
+
+    if version:
+        params["v"] = version.strip()
+
+    mapped_fields = {
+        "page_url": page_url,
+        "title": mapped_title,
+        "subtitle": mapped_subtitle,
+        "image_url": image_url,
+        "style": params["style"],
+        "site": params["site"],
+        "font": params["font"],
+        "eyebrow": params["eyebrow"],
+        "format": params["format"],
+    }
+
+    return WordPressRenderResult(params=params, mapped_fields=mapped_fields, fallbacks=fallbacks)
+
+
+def wordpress_helper_snippet(base_url: str, signed_url: str = "https://osig.app/g") -> str:
+    return f"""<?php
+/**
+ * Lightweight WordPress helper for OSIG job posts
+ */
+function build_osig_meta_tags($post = null, $key = '') {{
+    $post = $post ?: get_post();
+    $title = get_the_title($post) ?: get_the_archive_title();
+    $subtitle = get_the_excerpt($post) ?: wp_trim_words((string) get_the_content($post), 20);
+    $image = get_the_post_thumbnail_url($post, 'full')
+        ?: get_field('company_logo')
+        ?: get_custom_logo_url($key)
+        ?: '';
+
+    if (empty($title)) {{
+        $title = get_queried_object_id();
+    }}
+
+    $query = [
+        'key' => $key,
+        'title' => $title,
+        'subtitle' => $subtitle,
+        'image_url' => $image,
+        'style' => 'job_logo',
+        'site' => 'x',
+        'font' => 'helvetica',
+        'v' => gmdate('Y-m'),
+    ];
+
+    $query = array_filter($query, 'strlen');
+    return add_query_arg($query, '{base_url}');
+}}
+
+// Usage in your template:
+// <meta property="og:image" content="<?php echo esc_url(build_osig_meta_tags(null, '{{key}}')); ?>" />
+?>
+"""

--- a/docs/wordpress-helper-mvp.md
+++ b/docs/wordpress-helper-mvp.md
@@ -1,0 +1,69 @@
+# WordPress helper integration (MVP)
+
+Wave 1 task [8/8] adds a lightweight WordPress helper for mapping common post/CPT fields to OSIG image params with resilient fallbacks.
+
+## Endpoint
+
+`POST /api/integrations/wordpress`
+
+Input payload example:
+
+```json
+{
+  "page_url": "https://example.com/jobs/senior-engineer",
+  "post_title": "Senior Django Engineer",
+  "post_name": "senior-django-engineer",
+  "subtitle": "Join a remote product team",
+  "excerpt": "We build resilient hiring products",
+  "featured_image_url": "https://example.com/og-candidate.jpg",
+  "logo_url": "https://example.com/logo.png",
+  "fallback_image_url": "https://example.com/fallback.jpg",
+  "style": "job_logo",
+  "site": "x",
+  "font": "helvetica",
+  "key": "YOUR_OSIG_KEY",
+  "format": "jpeg",
+  "quality": 80,
+  "version": "v2026-02-26"
+}
+```
+
+Response shape:
+
+```json
+{
+  "signed_url": "https://osig.app/g?...&exp=...&sig=...",
+  "expires_at": "2026-02-26T12:34:56+00:00",
+  "mapped_fields": {
+    "title": "Senior Django Engineer",
+    "subtitle": "We build resilient hiring products",
+    "image_url": "https://example.com/logo.png",
+    "style": "job_logo",
+    "site": "x",
+    "font": "helvetica",
+    "format": "jpeg"
+  },
+  "fallbacks": [],
+  "snippet": "<?php ... ?>"
+}
+```
+
+## Mapping + fallback behavior
+
+Inputs are mapped in this order:
+
+- `title`: `title` -> `post_title` -> `seo_title` -> `post_name`(slugified)
+- `subtitle`: `subtitle` -> `excerpt` -> `description`
+- `image_url`: `featured_image_url` -> `featured_image` -> `logo_url`
+
+If there is no image, `fallback_image_url` is used (if provided). Otherwise, no image is attached and `image_missing` fallback is returned.
+
+## PHP snippet
+
+The response contains a small PHP helper snippet that can be dropped into themes/plugins.
+It:
+
+- reads common post fields,
+- resolves image/logo fallback chain,
+- generates a URL with OSIG query params,
+- can be adapted to call the signed endpoint for production keys.


### PR DESCRIPTION
## Summary
- Added WordPress helper MVP API at `POST /api/integrations/wordpress`.
- Maps common WordPress/post-CPT payload fields to OSIG generation params:
  - title precedence: `title` -> `post_title` -> `seo_title` -> slugized `post_name`
  - subtitle precedence: `subtitle` -> `excerpt` -> `description`
  - image precedence: `featured_image_url` -> `featured_image` -> `logo_url` with `fallback_image_url`
- Reuses signed URL primitives from existing flows (supports `quality`, `max_kb`, `v`, `format`, `site`, `font`, `style`, `key`, expiry).
- Includes fallback telemetry in response (`fallbacks`) and a PHP helper snippet for plugin/theme integration.
- Added dedicated helper utility module + tests + documentation.

## Files
- `core/api/schemas.py`
- `core/api/views.py`
- `core/wordpress_helper.py`
- `core/tests/test_wordpress_helper.py`
- `docs/wordpress-helper-mvp.md`
- `README.md`

## Testing
- `ENVIRONMENT=dev SECRET_KEY=test-secret DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1,testserver CSRF_TRUSTED_ORIGINS=http://localhost DATABASE_URL=sqlite:////tmp/osig-test.db AWS_S3_ENDPOINT_URL=http://localhost AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test REDIS_URL=redis://localhost:6379/0 GITHUB_CLIENT_ID=dummy GITHUB_CLIENT_SECRET=dummy MAILGUN_API_KEY=dummy BUTTONDOWN_API_KEY=dummy POSTHOG_API_KEY=dummy STRIPE_LIVE_SECRET_KEY=sk_test STRIPE_TEST_SECRET_KEY=sk_test DJSTRIPE_WEBHOOK_SECRET=whsec_test .venv/bin/python -m pytest core/tests/test_wordpress_helper.py -q`
- `ENVIRONMENT=dev SECRET_KEY=test-secret DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1,testserver CSRF_TRUSTED_ORIGINS=http://localhost DATABASE_URL=sqlite:////tmp/osig-test.db AWS_S3_ENDPOINT_URL=http://localhost AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test REDIS_URL=redis://localhost:6598/0 GITHUB_CLIENT_ID=dummy GITHUB_CLIENT_SECRET=dummy MAILGUN_API_KEY=dummy BUTTONDOWN_API_KEY=dummy POSTHOG_API_KEY=dummy STRIPE_LIVE_SECRET_KEY=sk_test STRIPE_TEST_SECRET_KEY=sk_test DJSTRIPE_WEBHOOK_SECRET=whsec_test .venv/bin/python -m pytest core/tests/test_generate_image_features.py core/tests/test_onboarding_wizard.py core/tests/test_usage_quota.py core/tests/test_render_reliability.py core/tests/test_wordpress_helper.py -q`

## Blockers
- none
