### PR TITLE
[CI] Remove Workers Process Type Repo Variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,17 +26,9 @@ jobs:
       - name: Prepare image name
         id: image
         shell: bash
-        run: echo "image_name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify workers process type
-        shell: bash
-        env:
-          WORKERS_APP_PROCESS_TYPE: ${{ vars.WORKERS_APP_PROCESS_TYPE }}
         run: |
-          if [ "$WORKERS_APP_PROCESS_TYPE" != "worker" ]; then
-            echo "::error::Set the WORKERS_APP_PROCESS_TYPE repository variable to 'worker' after setting APP_PROCESS_TYPE=worker on the $CAPROVER_APP_NAME-workers CapRover app."
-            exit 1
-          fi
+          image_name="ghcr.io/$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          echo "image_name=$image_name" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Python dependencies are managed with `uv`. For the Dockerized local stack, run:
 make serve
 ```
 
-The local backend and worker services use `Dockerfile-python`, and production deploys build one shared image from `deployment/Dockerfile`. At runtime, `APP_PROCESS_TYPE=server` starts Gunicorn and `APP_PROCESS_TYPE=worker` starts Django Q workers. For CapRover, set `APP_PROCESS_TYPE=server` on the `osig` app, `APP_PROCESS_TYPE=worker` on the `osig-workers` app, and the GitHub repository variable `WORKERS_APP_PROCESS_TYPE=worker`.
+The local backend and worker services use `Dockerfile-python`, and production deploys build one shared image from `deployment/Dockerfile`. At runtime, `APP_PROCESS_TYPE=server` starts Gunicorn and `APP_PROCESS_TYPE=worker` starts Django Q workers. For CapRover, set `APP_PROCESS_TYPE=server` on the `osig` app and `APP_PROCESS_TYPE=worker` on the `osig-workers` app.
 
 For AI-agent iteration on generated images, OSIG exposes a hosted FastMCP server at `/mcp/` from the web container. Hosted requests authenticate with an OSIG profile key via `X-API-Key` or `Authorization: Bearer <key>`.
 


### PR DESCRIPTION
## Summary
- remove the deploy workflow gate that required WORKERS_APP_PROCESS_TYPE
- keep deploy process selection in CapRover APP_PROCESS_TYPE only
- normalize GHCR image names to lowercase before build/deploy

## Verification
- pre-commit hooks: check yaml, end-of-file fixer, trailing whitespace
- git diff --check
- verified LVTD-LLC/osig normalizes to ghcr.io/lvtd-llc/osig