### PR TITLE
[Frontend] Major OSIG Site Redesign

### DIFF
--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["frontend/templates/**/*.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,45 @@
+# Design
+
+## Summary
+
+OSIG uses a restrained product UI system for a public utility site. The interface should make the generator, documentation, onboarding wizard, pricing, and account settings feel like one practical workflow.
+
+## Visual Theme
+
+- Mood: clear technical workspace, calm publishing utility, direct copy.
+- Surfaces: light neutral background, white working panels, soft secondary panels for supporting context.
+- Shape: 8px radius for panels, controls, previews, and repeated items.
+- Chrome: borders over shadows; use framing only where it helps identify a tool, form, preview, or plan.
+
+## Color
+
+Tokens live in `frontend/src/styles/index.css` and use OKLCH values.
+
+- `--osig-bg`: page background.
+- `--osig-surface`: primary content surface.
+- `--osig-surface-soft`: secondary surface.
+- `--osig-ink`: primary text.
+- `--osig-muted`: body and helper text.
+- `--osig-accent`: primary action blue.
+- `--osig-olive` and `--osig-amber`: logo-informed supporting colors.
+- `--osig-danger`, `--osig-success`, `--osig-warning`: semantic states.
+
+## Typography
+
+Use the system sans stack for all product UI. Headings rely on weight and compact tracking, not decorative fonts. Body copy should stay direct and specific, with line lengths capped on documentation and article surfaces.
+
+## Components
+
+- Buttons: `.btn-primary`, `.btn-secondary`, `.btn-danger`, `.btn-ghost`.
+- Forms: `.field-label`, `.field`, `.field-help`, `.copy-field`.
+- Layout: `.site-container`, `.site-container-narrow`, `.panel`, `.panel-soft`.
+- Content: `.page-kicker`, `.page-title`, `.section-title`, `.lede`, `.doc-prose`, `.code-block`.
+- Workflow: `.step-pill`, `.wizard-step-indicator`.
+
+## Interaction
+
+Motion is limited to short state transitions on navigation, buttons, dropdowns, wizard progress, generator status, and toasts. Reduced motion users receive instant or near-instant transitions. Generated preview and wizard states should always communicate what is happening in text, not color alone.
+
+## Accessibility
+
+Target WCAG AA contrast, visible focus states, keyboard reachable controls, semantic sections, useful button labels, and non-color state indicators. Keep generated URLs and code blocks copyable and horizontally scrollable on small screens.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+OSIG is for developers, founders, publishers, and small teams who need Open Graph and Twitter card images without opening a design tool for every page. They are usually in a publishing or integration flow: making a page share correctly, preparing a job post, wiring metadata into a CMS, or creating signed image URLs for repeatable use.
+
+## Product Purpose
+
+OSIG creates dynamic social preview images from URL parameters, signed API calls, and a guided onboarding flow. Success means a user can understand the available inputs, generate a useful image URL, copy the right metadata, and validate the result with minimal uncertainty.
+
+## Brand Personality
+
+Clear, practical, builder-focused. The product should feel direct and useful before it feels polished. The voice should explain exactly what will happen, name constraints plainly, and keep momentum toward a working preview image.
+
+## Anti-references
+
+Avoid generic SaaS presentation patterns that bury the working generator under vague marketing copy. Avoid dense documentation pages that make the user assemble the workflow from scattered parameter notes. Avoid visual treatments that make OSIG feel like a novelty toy instead of a reliable publishing utility.
+
+## Design Principles
+
+- Put the working path first: every important page should move the user toward generating, copying, signing, or validating an image URL.
+- Prefer specific labels over mood copy: headings, buttons, and helper text should say what the user can do next.
+- Make examples inspectable: previews, code, parameters, and validation links should be easy to compare and copy.
+- Keep the interface calm: use visual hierarchy, spacing, and restrained color to reduce uncertainty.
+- Preserve technical trust: forms, docs, pricing, and settings should feel consistent and predictable.
+
+## Accessibility & Inclusion
+
+Target WCAG AA contrast for text and controls. Support keyboard navigation and visible focus states on all interactive elements. Respect reduced motion preferences. Do not rely on color alone for state, validation, or pricing emphasis.

--- a/frontend/src/controllers/image_generator_controller.js
+++ b/frontend/src/controllers/image_generator_controller.js
@@ -1,12 +1,16 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["generatedImage", "generateLink", "copyButton"];
+  static targets = ["generatedImage", "generateLink", "copyButton", "status"];
   static values = { userKey: String };
 
   connect() {
     this.prefillGenerateLink();
     this.attachInputListeners();
+  }
+
+  disconnect() {
+    this.revokePreviewObjectUrl();
   }
 
   prefillGenerateLink() {
@@ -65,17 +69,38 @@ export default class extends Controller {
 
   generateImage() {
     const imageUrl = this.generateLinkTarget.value.replace(/\s+/g, '');
-    this.generatedImageTarget.innerHTML = '<p class="text-gray-500">Generating image...</p>';
+    this.revokePreviewObjectUrl();
+    this.setStatus("Generating");
+    this.generatedImageTarget.innerHTML = `
+      <div class="px-6 text-center">
+        <p class="font-semibold text-[var(--osig-ink)]">Generating preview...</p>
+        <p class="mt-2 text-sm text-[var(--osig-muted)]">Fetching the image URL from the server.</p>
+      </div>
+    `;
 
     fetch(imageUrl)
-      .then(response => response.blob())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Image request failed with status ${response.status}`);
+        }
+
+        return response.blob();
+      })
       .then(blob => {
-        const objectUrl = URL.createObjectURL(blob);
-        this.generatedImageTarget.innerHTML = `<img src="${objectUrl}" alt="Generated Image" class="w-full h-auto">`;
+        this.revokePreviewObjectUrl();
+        this.previewObjectUrl = URL.createObjectURL(blob);
+        this.generatedImageTarget.innerHTML = `<img src="${this.previewObjectUrl}" alt="Generated social preview image">`;
+        this.setStatus("Generated");
       })
       .catch(error => {
         console.error('Error generating image:', error);
-        this.generatedImageTarget.innerHTML = '<p class="text-red-500">An error occurred while generating the image. Please try again.</p>';
+        this.setStatus("Error");
+        this.generatedImageTarget.innerHTML = `
+          <div class="px-6 text-center">
+            <p class="font-semibold text-[var(--osig-danger)]">The preview could not be generated.</p>
+            <p class="mt-2 text-sm text-[var(--osig-muted)]">Check the image URL and required text fields, then try again.</p>
+          </div>
+        `;
       });
   }
 
@@ -84,10 +109,23 @@ export default class extends Controller {
       await navigator.clipboard.writeText(this.generateLinkTarget.value);
       this.copyButtonTarget.textContent = "Copied!";
       setTimeout(() => {
-        this.copyButtonTarget.textContent = "Copy";
+        this.copyButtonTarget.textContent = "Copy URL";
       }, 2000);
     } catch (err) {
       console.error('Failed to copy: ', err);
+    }
+  }
+
+  setStatus(status) {
+    if (this.hasStatusTarget) {
+      this.statusTarget.textContent = status;
+    }
+  }
+
+  revokePreviewObjectUrl() {
+    if (this.previewObjectUrl) {
+      URL.revokeObjectURL(this.previewObjectUrl);
+      this.previewObjectUrl = null;
     }
   }
 }

--- a/frontend/src/controllers/onboarding_wizard_controller.js
+++ b/frontend/src/controllers/onboarding_wizard_controller.js
@@ -22,6 +22,7 @@ export default class extends Controller {
     "previewLink",
     "errorMessage",
     "wizardForm",
+    "progressItem",
   ];
 
   connect() {
@@ -51,7 +52,11 @@ export default class extends Controller {
       step.classList.toggle("hidden", index !== this.currentStep);
     });
 
-    if (this.errorMessageTarget) {
+    this.progressItemTargets.forEach((item, index) => {
+      item.classList.toggle("is-active", index === this.currentStep);
+    });
+
+    if (this.hasErrorMessageTarget) {
       this.errorMessageTarget.textContent = "";
     }
   }
@@ -80,6 +85,8 @@ export default class extends Controller {
       const data = await response.json();
       this.metaTagsTarget.value = data.meta_tags;
       this.previewLinkTarget.href = data.signed_url;
+      this.previewLinkTarget.classList.remove("hidden");
+      this.previewLinkTarget.removeAttribute("aria-disabled");
       this.renderValidationLinks(data.validation_links);
     } catch (error) {
       this.setError(error.message || "Unable to generate onboarding artifacts.");
@@ -102,6 +109,8 @@ export default class extends Controller {
     this.currentStep = 0;
     this.metaTagsTarget.value = "";
     this.previewLinkTarget.href = "#";
+    this.previewLinkTarget.classList.add("hidden");
+    this.previewLinkTarget.setAttribute("aria-disabled", "true");
     this.validationLinksTarget.innerHTML = "";
     this.clearError();
     this.updateStepVisibility();
@@ -153,12 +162,10 @@ export default class extends Controller {
       link.href = href;
       link.target = "_blank";
       link.rel = "noopener noreferrer";
-      link.className = "inline-block mr-3 text-sm text-blue-600 underline";
+      link.className = "btn-secondary min-h-0 px-3 py-2";
       link.textContent = name;
 
-      const wrapper = document.createElement("div");
-      wrapper.appendChild(link);
-      this.validationLinksTarget.appendChild(wrapper);
+      this.validationLinksTarget.appendChild(link);
     });
   }
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -2,8 +2,449 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@layer base {
+  :root {
+    --osig-bg: oklch(0.978 0.006 230);
+    --osig-surface: oklch(1 0 0);
+    --osig-surface-soft: oklch(0.955 0.011 228);
+    --osig-surface-tint: oklch(0.927 0.018 228);
+    --osig-ink: oklch(0.19 0.033 248);
+    --osig-muted: oklch(0.42 0.034 250);
+    --osig-soft: oklch(0.55 0.032 250);
+    --osig-line: oklch(0.87 0.018 235);
+    --osig-accent: oklch(0.51 0.155 252);
+    --osig-accent-strong: oklch(0.41 0.15 254);
+    --osig-accent-soft: oklch(0.93 0.035 246);
+    --osig-olive: oklch(0.58 0.117 111);
+    --osig-amber: oklch(0.84 0.112 91);
+    --osig-danger: oklch(0.53 0.19 29);
+    --osig-danger-soft: oklch(0.96 0.026 29);
+    --osig-success: oklch(0.49 0.118 155);
+    --osig-success-soft: oklch(0.95 0.035 155);
+    --osig-warning: oklch(0.56 0.104 82);
+    --osig-warning-soft: oklch(0.96 0.045 92);
+    --osig-code: oklch(0.17 0.025 250);
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    margin: 0;
+    background: var(--osig-bg);
+    color: var(--osig-ink);
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    text-rendering: optimizeLegibility;
+  }
+
+  h1,
+  h2,
+  h3 {
+    color: var(--osig-ink);
+    text-wrap: balance;
+  }
+
+  p,
+  li {
+    text-wrap: pretty;
+  }
+
+  ::selection {
+    background: var(--osig-accent-soft);
+    color: var(--osig-ink);
+  }
+}
+
 @layer components {
   .link {
-    @apply text-blue-400 underline;
+    color: var(--osig-accent-strong);
+    font-weight: 650;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  .site-shell {
+    min-height: 100vh;
+    background: var(--osig-bg);
+  }
+
+  .site-container {
+    width: min(calc(100% - 2rem), 72rem);
+    margin-inline: auto;
+  }
+
+  .site-container-narrow {
+    width: min(calc(100% - 2rem), 54rem);
+    margin-inline: auto;
+  }
+
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    border-bottom: 1px solid color-mix(in oklch, var(--osig-line), transparent 35%);
+    background: color-mix(in oklch, var(--osig-surface), transparent 7%);
+    backdrop-filter: blur(14px);
+  }
+
+  .brand-mark {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: var(--osig-ink);
+    font-weight: 760;
+    letter-spacing: 0;
+  }
+
+  .brand-mark img {
+    height: 2rem;
+    width: 2rem;
+    border-radius: 0.5rem;
+  }
+
+  .nav-link {
+    color: var(--osig-muted);
+    font-size: 0.925rem;
+    font-weight: 650;
+    line-height: 1.5rem;
+    transition: color 160ms ease, background-color 160ms ease;
+  }
+
+  .nav-link:hover {
+    color: var(--osig-ink);
+  }
+
+  .mobile-panel {
+    background: var(--osig-surface);
+    border-inline-start: 1px solid var(--osig-line);
+  }
+
+  .page-kicker {
+    color: var(--osig-accent-strong);
+    font-size: 0.875rem;
+    font-weight: 750;
+  }
+
+  .page-title {
+    color: var(--osig-ink);
+    font-size: 2.15rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    line-height: 1.02;
+    overflow-wrap: break-word;
+  }
+
+  .section-title {
+    color: var(--osig-ink);
+    font-size: 1.8rem;
+    font-weight: 760;
+    letter-spacing: -0.02em;
+    line-height: 1.08;
+    overflow-wrap: break-word;
+  }
+
+  .lede {
+    color: var(--osig-muted);
+    font-size: 1.05rem;
+    line-height: 1.75rem;
+  }
+
+  .panel {
+    border: 1px solid var(--osig-line);
+    border-radius: 0.5rem;
+    background: var(--osig-surface);
+  }
+
+  .panel-soft {
+    border: 1px solid color-mix(in oklch, var(--osig-line), transparent 30%);
+    border-radius: 0.5rem;
+    background: var(--osig-surface-soft);
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .btn-danger,
+  .btn-ghost {
+    display: inline-flex;
+    min-height: 2.65rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border-radius: 0.5rem;
+    padding: 0.65rem 1rem;
+    font-size: 0.925rem;
+    font-weight: 750;
+    line-height: 1.25rem;
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+  }
+
+  .btn-primary {
+    border: 1px solid var(--osig-accent-strong);
+    background: var(--osig-accent);
+    color: white;
+  }
+
+  .btn-primary:hover {
+    background: var(--osig-accent-strong);
+  }
+
+  .btn-secondary {
+    border: 1px solid var(--osig-line);
+    background: var(--osig-surface);
+    color: var(--osig-ink);
+  }
+
+  .btn-secondary:hover {
+    border-color: color-mix(in oklch, var(--osig-accent), var(--osig-line) 45%);
+    background: var(--osig-accent-soft);
+  }
+
+  .btn-danger {
+    border: 1px solid var(--osig-danger);
+    background: var(--osig-danger);
+    color: white;
+  }
+
+  .btn-danger:hover {
+    background: oklch(0.46 0.18 29);
+  }
+
+  .btn-ghost {
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--osig-muted);
+  }
+
+  .btn-ghost:hover {
+    background: var(--osig-surface-soft);
+    color: var(--osig-ink);
+  }
+
+  .btn-primary:focus-visible,
+  .btn-secondary:focus-visible,
+  .btn-danger:focus-visible,
+  .btn-ghost:focus-visible,
+  .field:focus-visible,
+  .copy-field:focus-visible,
+  .nav-link:focus-visible,
+  .link:focus-visible {
+    outline: 3px solid color-mix(in oklch, var(--osig-accent), white 38%);
+    outline-offset: 2px;
+  }
+
+  .field-label {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--osig-ink);
+    font-size: 0.875rem;
+    font-weight: 720;
+  }
+
+  .field,
+  .copy-field {
+    width: 100%;
+    border: 1px solid var(--osig-line);
+    border-radius: 0.5rem;
+    background: var(--osig-surface);
+    color: var(--osig-ink);
+    font-size: 0.95rem;
+  }
+
+  .field {
+    padding: 0.7rem 0.8rem;
+  }
+
+  .copy-field {
+    padding: 0.85rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 0.8rem;
+    line-height: 1.55;
+  }
+
+  .field::placeholder,
+  .copy-field::placeholder {
+    color: color-mix(in oklch, var(--osig-muted), white 18%);
+    opacity: 1;
+  }
+
+  .field-help {
+    margin-top: 0.4rem;
+    color: var(--osig-soft);
+    font-size: 0.8rem;
+    line-height: 1.3rem;
+  }
+
+  .preview-frame {
+    display: flex;
+    min-height: 15rem;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    border: 1px solid var(--osig-line);
+    background: var(--osig-surface-soft);
+    aspect-ratio: 16 / 9;
+  }
+
+  .preview-frame img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background: var(--osig-surface);
+  }
+
+  .code-block {
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    background: var(--osig-code);
+    color: oklch(0.94 0.01 230);
+    padding: 1rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 0.82rem;
+    line-height: 1.6;
+  }
+
+  .doc-prose {
+    color: var(--osig-muted);
+    font-size: 1rem;
+    line-height: 1.75;
+  }
+
+  .doc-prose h2 {
+    margin-top: 2.75rem;
+    margin-bottom: 0.9rem;
+    color: var(--osig-ink);
+    font-size: 1.65rem;
+    font-weight: 760;
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+  }
+
+  .doc-prose h3 {
+    margin-top: 2rem;
+    margin-bottom: 0.65rem;
+    color: var(--osig-ink);
+    font-size: 1.2rem;
+    font-weight: 750;
+  }
+
+  .doc-prose p {
+    margin-bottom: 1rem;
+  }
+
+  .doc-prose ul {
+    margin: 1rem 0;
+    padding-left: 1.25rem;
+    list-style: disc;
+  }
+
+  .doc-prose li {
+    margin: 0.45rem 0;
+  }
+
+  .doc-prose strong {
+    color: var(--osig-ink);
+    font-weight: 750;
+  }
+
+  .doc-prose a {
+    color: var(--osig-accent-strong);
+    font-weight: 650;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .doc-prose :not(pre) > code {
+    border-radius: 0.35rem;
+    background: var(--osig-surface-tint);
+    color: var(--osig-ink);
+    padding: 0.15rem 0.35rem;
+    font-size: 0.9em;
+  }
+
+  .doc-prose img {
+    border: 1px solid var(--osig-line);
+    border-radius: 0.5rem;
+    background: var(--osig-surface);
+  }
+
+  .status-note {
+    border-radius: 0.5rem;
+    border: 1px solid var(--osig-line);
+    background: var(--osig-surface-soft);
+    padding: 0.9rem 1rem;
+    color: var(--osig-muted);
+    font-size: 0.9rem;
+    line-height: 1.45rem;
+  }
+
+  .step-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: var(--osig-accent-soft);
+    color: var(--osig-accent-strong);
+    font-size: 0.85rem;
+    font-weight: 780;
+  }
+
+  .wizard-step-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    color: var(--osig-soft);
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
+  .wizard-step-indicator .step-pill {
+    background: var(--osig-surface-tint);
+    color: var(--osig-muted);
+  }
+
+  .wizard-step-indicator.is-active {
+    background: var(--osig-accent-soft);
+    color: var(--osig-accent-strong);
+  }
+
+  .wizard-step-indicator.is-active .step-pill {
+    background: var(--osig-accent);
+    color: white;
+  }
+}
+
+@media (min-width: 768px) {
+  .page-title {
+    font-size: 4.5rem;
+    letter-spacing: -0.035em;
+    line-height: 0.98;
+  }
+
+  .section-title {
+    font-size: 2.75rem;
+    letter-spacing: -0.025em;
+    line-height: 1.05;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.001ms !important;
   }
 }

--- a/frontend/templates/account/email_confirm.html
+++ b/frontend/templates/account/email_confirm.html
@@ -14,37 +14,38 @@
 {% endblock schema %}
 
 {% block content %}
-<div class="container px-4 py-8 mx-auto">
-    <div class="mx-auto max-w-3xl">
-        <h1 class="mb-8 text-3xl font-bold text-center">
-            Confirm Email Address
+<section class="site-container-narrow py-12 lg:py-16">
+    <div class="panel mx-auto max-w-xl p-6">
+        <p class="page-kicker">Account</p>
+        <h1 class="mt-3 text-3xl font-extrabold tracking-tight text-[var(--osig-ink)]">
+            Confirm email address
         </h1>
 
         {% if confirmation %}
             {% user_display confirmation.email_address.user as user_display %}
             {% if can_confirm %}
-                <p class="mb-6 text-center">
-                    Please confirm that <a href="mailto:{{ confirmation.email_address.email }}" class="text-blue-600 hover:underline">{{ confirmation.email_address.email }}</a> is an email address for user {{ user_display }}.
+                <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+                    Confirm that <a href="mailto:{{ confirmation.email_address.email }}" class="link">{{ confirmation.email_address.email }}</a> belongs to {{ user_display }}.
                 </p>
                 {% url 'account_confirm_email' confirmation.key as action_url %}
-                <form method="post" action="{{ action_url }}" class="flex justify-center">
+                <form method="post" action="{{ action_url }}" class="mt-6">
                     {% csrf_token %}
                     {{ redirect_field }}
-                    <button type="submit" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                        Confirm
+                    <button type="submit" class="btn-primary">
+                        Confirm email
                     </button>
                 </form>
             {% else %}
-                <p class="text-center text-red-600">
+                <p class="mt-4 text-sm font-semibold text-[var(--osig-danger)]">
                     Unable to confirm {{ confirmation.email_address.email }} because it is already confirmed by a different account.
                 </p>
             {% endif %}
         {% else %}
             {% url 'account_email' as email_url %}
-            <p class="text-center">
-                This email confirmation link expired or is invalid. Please <a href="{{ email_url }}" class="text-blue-600 hover:underline">issue a new email confirmation request</a>.
+            <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+                This email confirmation link expired or is invalid. Please <a href="{{ email_url }}" class="link">request a new confirmation email</a>.
             </p>
         {% endif %}
     </div>
-</div>
+</section>
 {% endblock content %}

--- a/frontend/templates/account/login.html
+++ b/frontend/templates/account/login.html
@@ -11,83 +11,53 @@
 {% endblock schema %}
 
 {% block content %}
-    <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
-        <div class="space-y-8 w-full max-w-md">
+    <div class="site-container-narrow py-12 lg:py-16">
+        <div class="panel mx-auto max-w-md p-6">
             <div>
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
-                    Sign in to your account
-                </h2>
-                <p class="mt-2 text-sm text-center text-gray-600">
-                    Or
-                    <a href="{% url 'account_signup' %}" class="font-medium text-blue-600 hover:text-blue-500">
-                        sign up if you don't have one yet.
-                    </a>
+                <p class="page-kicker">Account</p>
+                <h1 class="mt-3 text-3xl font-extrabold tracking-tight text-[var(--osig-ink)]">Log in to OSIG</h1>
+                <p class="mt-3 text-sm leading-6 text-[var(--osig-muted)]">
+                    Need an account?
+                    <a href="{% url 'account_signup' %}" class="link">Create one</a>.
                 </p>
             </div>
-            <form class="mt-8 space-y-6" method="post" action="{% url 'account_login' %}">
+            <form class="mt-6 space-y-4" method="post" action="{% url 'account_login' %}">
                 {% csrf_token %}
                 {{ form.non_field_errors | safe }}
                 <input type="hidden" name="remember" value="true" />
-                <div class="-space-y-px rounded-md shadow-sm">
-                    <div>
-                        {{ form.login.errors | safe }}
-                        <label for="username" class="sr-only">Username</label>
-                        {% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
-                    </div>
-                    <div>
-                        {{ form.password.errors | safe }}
-                        <label for="password" class="sr-only">Password</label>
-                        {% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" placeholder="Password" %}
-                    </div>
-                </div>
-
-                 {% if redirect_field_value %}
-                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-                 {% endif %}
-
                 <div>
-                    <button type="submit"
-                            class="flex relative justify-center px-4 py-2 w-full text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent border-solid group hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                        <span class="flex absolute inset-y-0 left-0 items-center pl-3">
-                            <!-- Heroicon name: solid/lock-closed -->
-                            <svg class="w-5 h-5 text-blue-500 group-hover:text-blue-400"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 viewBox="0 0 20 20"
-                                 fill="currentColor"
-                                 aria-hidden="true">
-                                <path fill-rule="evenodd"
-                                      d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
-                                      clip-rule="evenodd"/>
-                            </svg>
-                        </span>
-                        Sign in
-                    </button>
+                    {{ form.login.errors | safe }}
+                    <label for="username" class="field-label">Username</label>
+                    {% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="field" %}
                 </div>
+                <div>
+                    {{ form.password.errors | safe }}
+                    <label for="password" class="field-label">Password</label>
+                    {% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="field" placeholder="Password" %}
+                </div>
+
+                {% if redirect_field_value %}
+                <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+                {% endif %}
+
+                <button type="submit" class="btn-primary w-full">Log in</button>
             </form>
 
-            <div>
-              <div class="relative mt-10">
-                <div class="flex absolute inset-0 items-center" aria-hidden="true">
-                  <div class="w-full border-t border-gray-200"></div>
-                </div>
-                <div class="flex relative justify-center text-sm font-medium leading-6">
-                  <span class="px-6 text-gray-900 bg-white">Or continue with</span>
-                </div>
-              </div>
-
-              <div class="grid grid-cols-1 gap-4 mt-6">
-                <form method="post" action="{% provider_login_url 'github' %}">
-                {% csrf_token %}
-                  <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent">
-                    <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                      <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
-                    </svg>
-                    <span class="text-sm font-semibold leading-6">GitHub</span>
-                  </button>
-                </form>
-              </div>
+            <div class="my-6 flex items-center gap-4">
+              <div class="h-px flex-1 bg-[var(--osig-line)]"></div>
+              <span class="text-sm font-semibold text-[var(--osig-soft)]">or</span>
+              <div class="h-px flex-1 bg-[var(--osig-line)]"></div>
             </div>
 
+            <form method="post" action="{% provider_login_url 'github' %}">
+              {% csrf_token %}
+              <button class="btn-secondary w-full">
+                <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
+                </svg>
+                Continue with GitHub
+              </button>
+            </form>
         </div>
     </div>
 {% endblock content %}

--- a/frontend/templates/account/logout.html
+++ b/frontend/templates/account/logout.html
@@ -10,19 +10,23 @@
 {% endblock schema %}
 
 {% block content %}
-    <div class="mx-auto my-4 prose md:my-10 lg:prose-lg">
-        <h1 class="text-center">Please confirm Sign Out</h1>
-        <form method="post" class="flex flex-row justify-center" action="{% url 'account_logout' %}">
-            {% csrf_token %}
+    <section class="site-container-narrow py-12 lg:py-16">
+        <div class="panel mx-auto max-w-md p-6 text-center">
+            <p class="page-kicker">Account</p>
+            <h1 class="mt-3 text-3xl font-extrabold tracking-tight text-[var(--osig-ink)]">Sign out?</h1>
+            <p class="mt-3 text-sm leading-6 text-[var(--osig-muted)]">Confirm before ending your OSIG session.</p>
+            <form method="post" class="mt-6 flex justify-center" action="{% url 'account_logout' %}">
+                {% csrf_token %}
 
-            {% if redirect_field_value %}
+                {% if redirect_field_value %}
                 <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
-            {% endif %}
+                {% endif %}
 
-            <button class="inline-flex items-center px-6 py-3 text-base font-medium text-white bg-red-600 rounded-md border border-transparent border-solid shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                    type="submit">
-                Sign Out
-            </button>
-        </form>
-    </div>
+                <button class="btn-danger"
+                        type="submit">
+                    Sign out
+                </button>
+            </form>
+        </div>
+    </section>
 {% endblock content %}

--- a/frontend/templates/account/signup.html
+++ b/frontend/templates/account/signup.html
@@ -11,94 +11,68 @@
 {% endblock schema %}
 
 {% block content %}
-<div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
-  <div class="space-y-8 w-full max-w-md">
+<div class="site-container-narrow py-12 lg:py-16">
+  <div class="panel mx-auto max-w-md p-6">
       <div>
-          <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
-              Create your account
-          </h2>
-          <p class="mt-2 text-sm text-center text-gray-600">
-            Or
-            <a href="{% url 'account_login' %}" class="font-medium text-blue-600 hover:text-blue-500">
-                login if you have one already.
-            </a>
-        </p>
+          <p class="page-kicker">Account</p>
+          <h1 class="mt-3 text-3xl font-extrabold tracking-tight text-[var(--osig-ink)]">
+              Create your OSIG account
+          </h1>
+          <p class="mt-3 text-sm leading-6 text-[var(--osig-muted)]">
+            Already have an account?
+            <a href="{% url 'account_login' %}" class="link">
+                Log in
+            </a>.
+          </p>
       </div>
-      <form class="mt-8 space-y-6" id="signup_form" method="post" action="{% url 'account_signup' %}">
+      <form class="mt-6 space-y-4" id="signup_form" method="post" action="{% url 'account_signup' %}">
         {% csrf_token %}
 
         {{ form.non_field_errors | safe }}
         <input type="hidden" name="remember" value="true" />
-        <div class="-space-y-px rounded-md shadow-sm">
-          <div>
-            {{ form.username.errors | safe }}
-            <label for="username" class="sr-only">Username</label>
-            {% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
-          </div>
-          <div>
-            {{ form.email.errors | safe }}
-            <label for="email" class="sr-only">Username</label>
-            {% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
-          </div>
-          <div>
-            {{ form.password1.errors | safe }}
-            <label for="password1" class="sr-only">Password</label>
-            {% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
-          </div>
-          <div>
-            {{ form.password2.errors | safe }}
-            <label for="password2" class="sr-only">Password</label>
-            {% render_field form.password2 id="password2" name="password2" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" placeholder="Cofirm Password" %}
-          </div>
+        <div>
+          {{ form.username.errors | safe }}
+          <label for="username" class="field-label">Username</label>
+          {% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="field" %}
+        </div>
+        <div>
+          {{ form.email.errors | safe }}
+          <label for="email" class="field-label">Email</label>
+          {% render_field form.email id="email" name="email" placeholder="you@example.com" type="email" autocomplete="email" required="True" class="field" %}
+        </div>
+        <div>
+          {{ form.password1.errors | safe }}
+          <label for="password1" class="field-label">Password</label>
+          {% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="new-password" required="True" class="field" %}
+        </div>
+        <div>
+          {{ form.password2.errors | safe }}
+          <label for="password2" class="field-label">Confirm password</label>
+          {% render_field form.password2 id="password2" name="password2" type="password" autocomplete="new-password" required="True" class="field" placeholder="Confirm password" %}
         </div>
 
         {% if redirect_field_value %}
         <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
         {% endif %}
 
-        <div>
-            <button type="submit"
-                    class="flex relative justify-center px-4 py-2 w-full text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent border-solid group hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                <span class="flex absolute inset-y-0 left-0 items-center pl-3">
-                    <!-- Heroicon name: solid/lock-closed -->
-                    <svg class="w-5 h-5 text-blue-500 group-hover:text-blue-400"
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                          aria-hidden="true">
-                        <path fill-rule="evenodd"
-                              d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
-                              clip-rule="evenodd"/>
-                    </svg>
-                </span>
-                Sign up
-            </button>
-        </div>
+        <button type="submit" class="btn-primary w-full">Create account</button>
       </form>
 
-      <div>
-        <div class="relative mt-10">
-          <div class="flex absolute inset-0 items-center" aria-hidden="true">
-            <div class="w-full border-t border-gray-200"></div>
-          </div>
-          <div class="flex relative justify-center text-sm font-medium leading-6">
-            <span class="px-6 text-gray-900 bg-white">Or continue with</span>
-          </div>
-        </div>
-
-        <div class="grid grid-cols-1 gap-4 mt-6">
-          <form method="post" action="{% provider_login_url 'github' %}">
-            {% csrf_token %}
-              <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent">
-                <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
-                </svg>
-                <span class="text-sm font-semibold leading-6">GitHub</span>
-              </button>
-            </form>
-        </div>
+      <div class="my-6 flex items-center gap-4">
+        <div class="h-px flex-1 bg-[var(--osig-line)]"></div>
+        <span class="text-sm font-semibold text-[var(--osig-soft)]">or</span>
+        <div class="h-px flex-1 bg-[var(--osig-line)]"></div>
       </div>
 
+      <form method="post" action="{% provider_login_url 'github' %}">
+        {% csrf_token %}
+        <button class="btn-secondary w-full">
+          <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
+          </svg>
+          Continue with GitHub
+        </button>
+      </form>
     </div>
   </div>
 {% endblock content %}

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -56,207 +56,135 @@
     {% include "components/messages.html" with messages=messages %}
   {% endblock default_messages %}
 
-  <div class="bg-white">
-    <header class="bg-white">
-      <nav class="flex justify-between items-center p-6 mx-auto max-w-7xl lg:px-8" aria-label="Global">
+  <div class="site-shell">
+    <header class="site-header">
+      <nav class="site-container flex h-16 items-center justify-between" aria-label="Global">
+        <a href="{% url 'home' %}" class="brand-mark">
+          <img src="{% static 'vendors/images/logo.png' %}" alt="" />
+          <span>OSIG</span>
+        </a>
 
-        <!-- Small Screen -->
-        <div class="flex justify-between items-center w-full lg:hidden">
-
-          <div class="relative">
-            <div data-controller="dropdown">
-              <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" id="user-menu-button" aria-expanded="false" aria-haspopup="true">
-                <span class="sr-only">Open user menu</span>
-                <svg class="w-6 h-6 group-[.open]:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-                </svg>
-                <svg class="hidden w-6 h-6 group-[.open]:block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                </svg>
-              </button>
-              <div data-dropdown-target="menu" class="hidden lg:hidden" role="dialog" aria-modal="true">
-                <!-- Background backdrop, show/hide based on slide-over state. -->
-                <div class="fixed inset-0 z-10"></div>
-                <div class="overflow-y-auto fixed inset-y-0 right-0 z-10 px-6 py-6 w-full bg-white sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
-                  <div class="flex justify-start items-center">
-                    <button data-action="dropdown#toggle click@window->dropdown#hide" type="button">
-                      <span class="sr-only">Close menu</span>
-                      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                      </svg>
-                    </button>
-                  </div>
-                  <div class="flow-root mt-6">
-                    <div class="flex flex-col justify-start space-y-1">
-                      <a href="{% url 'home' %}" class="flex flex-row justify-center items-center p-1.5 -m-1.5 mb-2 space-x-2">
-                        <img class="w-auto h-8" src="{% static 'vendors/images/logo.png' %}" alt="OSIG Logo" />
-                        <span class="text-base font-semibold text-gray-700">OSIG</span>
-                      </a>
-                      <a href="{% url 'home' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        Home
-                      </a>
-                      <a href="{% url 'how_to' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        How to use?
-                      </a>
-                      <a href="{% url 'onboarding_wizard' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        Onboarding
-                      </a>
-                      <a href="{% url 'blog_posts' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        Blog
-                      </a>
-                      <a href="{% url 'pricing' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        Pricing
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Profile dropdown (right) -->
-          <div class="relative">
-            {% if user.is_authenticated %}
-            <div data-controller="dropdown">
-              <button type="button" data-action="dropdown#toggle click@window->dropdown#hide"
-                class="flex text-sm bg-gray-800 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-                id="user-menu-button" aria-expanded="false" aria-haspopup="true">
-                <span class="sr-only">Open user menu</span>
-                <img class="object-cover p-1 w-10 h-10 bg-gray-100 rounded-full border-2 border-gray-500"
-                  src="{% static 'vendors/images/unknown-man.png' %}" alt="No Personal Photo" />
-              </button>
-              <div data-dropdown-target="menu" class="hidden lg:hidden" role="dialog" aria-modal="true">
-                <!-- Background backdrop, show/hide based on slide-over state. -->
-                <div class="fixed inset-0 z-10"></div>
-                <div class="overflow-y-auto fixed inset-y-0 right-0 z-10 px-6 py-6 w-full bg-white sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
-                  <div class="flex justify-end items-center">
-                    <button data-action="dropdown#toggle click@window->dropdown#hide" type="button"
-                      class="p-2.5 -m-2.5 text-gray-700 rounded-md">
-                      <span class="sr-only">Close menu</span>
-                      <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-                        aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
-                  <div class="flow-root mt-6">
-                    <div class="flex justify-end">
-                      <a href="{% url 'settings' %}" class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50">
-                        Settings
-                      </a>
-                    </div>
-                    <div class="-my-6 divide-y divide-gray-500/10">
-                      <div class="py-6">
-                        <form method="post" class="flex justify-end" action="{% url 'account_logout' %}">
-                          {% csrf_token %}
-                          <button
-                            class="px-3 py-2.5 -mx-3 text-base font-semibold leading-7 text-center text-gray-900 rounded-lg hover:bg-gray-50"
-                            role="menuitem"
-                            data-action="dropdown#toggle"
-                            tabindex="-1"
-                            id="user-menu-item-2"
-                            type="submit"
-                          >
-                              Sign Out
-                          </button>
-                        </form>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            {% else %}
-            <a href="{% url 'account_login' %}" class="text-base font-semibold leading-6 text-gray-900">
-              Log in <span aria-hidden="true">&rarr;</span>
-            </a>
-            {% endif %}
-          </div>
-
+        <div class="hidden items-center gap-7 lg:flex">
+          <a href="{% url 'home' %}#generator" class="nav-link">Generator</a>
+          <a href="{% url 'how_to' %}" class="nav-link">Docs</a>
+          <a href="{% url 'onboarding_wizard' %}" class="nav-link">Wizard</a>
+          <a href="{% url 'blog_posts' %}" class="nav-link">Guides</a>
+          <a href="{% url 'pricing' %}" class="nav-link">Pricing</a>
         </div>
 
-        <!-- Large Screen -->
-        <div class="hidden lg:flex lg:justify-between lg:items-center lg:w-full">
-          <div class="flex gap-x-12 items-center">
-            <a href="{% url 'home' %}" class="flex flex-row justify-between items-center p-1.5 -m-1.5 space-x-2">
-              <img class="w-auto h-8" src="{% static 'vendors/images/logo.png' %}" alt="OSIG Logo" />
-              <span class="text-base font-semibold text-gray-700">OSIG</span>
-            </a>
-          </div>
-          <div class="flex items-center space-x-8">
-            <a href="{% url 'how_to' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
-              How to use?
-            </a>
-            <a href="{% url 'onboarding_wizard' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
-              Onboarding
-            </a>
-            <a href="{% url 'blog_posts' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
-              Blog
-            </a>
-            <a href="{% url 'pricing' %}" class="text-base font-semibold leading-6 text-gray-900 hover:text-gray-700">
-              Pricing
-            </a>
-            {% if user.is_authenticated %}
-            <!-- Profile dropdown -->
-            <div data-controller="dropdown" class="relative ml-3">
-              <div>
-                <button type="button" data-action="dropdown#toggle click@window->dropdown#hide"
-                  class="flex text-sm bg-gray-800 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-                  id="user-menu-button" aria-expanded="false" aria-haspopup="true">
-                  <span class="sr-only">Open user menu</span>
-                  <img class="object-cover p-1 w-10 h-10 bg-gray-100 rounded-full border-2 border-gray-500"
-                    src="{% static 'vendors/images/unknown-man.png' %}" alt="No Personal Photo" />
+        <div class="hidden items-center gap-3 lg:flex">
+          {% if user.is_authenticated %}
+          <a href="{% url 'settings' %}" class="btn-secondary">Settings</a>
+          <div data-controller="dropdown" class="relative">
+            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide"
+              class="flex rounded-full border border-[var(--osig-line)] bg-white p-1 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--osig-accent)]"
+              id="desktop-user-menu-button" aria-expanded="false" aria-haspopup="true">
+              <span class="sr-only">Open account menu</span>
+              <img class="h-8 w-8 rounded-full object-cover"
+                src="{% static 'vendors/images/unknown-man.png' %}" alt="" />
+            </button>
+            <div data-dropdown-target="menu"
+              class="panel hidden absolute right-0 z-20 mt-2 w-48 overflow-hidden p-1"
+              role="menu" aria-orientation="vertical" aria-labelledby="desktop-user-menu-button" tabindex="-1">
+              <a href="{% url 'settings' %}" class="block rounded-md px-3 py-2 text-sm font-semibold text-[var(--osig-ink)] hover:bg-[var(--osig-surface-soft)]">
+                Settings
+              </a>
+              <form method="post" action="{% url 'account_logout' %}">
+                {% csrf_token %}
+                <button
+                  class="block w-full rounded-md px-3 py-2 text-left text-sm font-semibold text-[var(--osig-ink)] hover:bg-[var(--osig-surface-soft)]"
+                  role="menuitem"
+                  data-action="dropdown#toggle"
+                  type="submit"
+                >
+                  Sign out
                 </button>
-              </div>
-              <div data-dropdown-target="menu"
-                class="hidden absolute right-0 z-10 py-1 mt-2 w-48 bg-white rounded-md ring-1 ring-black ring-opacity-5 shadow-lg origin-top-right focus:outline-none"
-                role="menu" aria-orientation="vertical" aria-labelledby="user-menu-button" tabindex="-1">
-                <a href="{% url 'settings' %}" class="flex justify-start px-4 py-2 w-full text-sm text-gray-700 hover:bg-gray-300">
-                  Settings
-                </a>
-                <form method="post" action="{% url 'account_logout' %}">
-                  {% csrf_token %}
-                  <button
-                    class="flex justify-start px-4 py-2 w-full text-sm text-gray-700 hover:bg-gray-300"
-                    role="menuitem"
-                    data-action="dropdown#toggle"
-                    tabindex="-1"
-                    id="user-menu-item-2"
-                    type="submit"
-                  >
-                      Sign Out
-                  </button>
-                </form>
-              </div>
+              </form>
             </div>
-            {% else %}
-            <a href="{% url 'account_login' %}" class="text-base font-semibold leading-6 text-gray-900">
-                Log in <span aria-hidden="true">&rarr;</span>
-            </a>
-            {% endif %}
           </div>
+          {% else %}
+          <a href="{% url 'account_login' %}" class="btn-secondary">Log in</a>
+          <a href="{% url 'account_signup' %}" class="btn-primary">Create image URLs</a>
+          {% endif %}
         </div>
 
+        <div class="flex items-center gap-3 lg:hidden">
+          {% if user.is_authenticated %}
+          <a href="{% url 'settings' %}" class="btn-secondary min-h-0 px-3 py-2">Settings</a>
+          {% else %}
+          <a href="{% url 'account_login' %}" class="btn-secondary min-h-0 px-3 py-2">Log in</a>
+          {% endif %}
+
+          <div data-controller="dropdown" class="relative">
+            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" id="mobile-menu-button" aria-expanded="false" aria-haspopup="true" class="btn-secondary min-h-0 px-3 py-2">
+              <span class="sr-only">Open navigation menu</span>
+              <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7h16M4 12h16M4 17h16"></path>
+              </svg>
+            </button>
+            <div data-dropdown-target="menu" class="hidden lg:hidden" role="dialog" aria-modal="true">
+              <div class="fixed inset-0 z-10 bg-slate-950/20"></div>
+              <div class="mobile-panel fixed inset-y-0 right-0 z-20 w-full max-w-sm overflow-y-auto px-5 py-5">
+                <div class="flex items-center justify-between">
+                  <a href="{% url 'home' %}" class="brand-mark">
+                    <img src="{% static 'vendors/images/logo.png' %}" alt="" />
+                    <span>OSIG</span>
+                  </a>
+                  <button data-action="dropdown#toggle click@window->dropdown#hide" type="button" class="btn-ghost min-h-0 px-3 py-2">
+                    <span class="sr-only">Close navigation menu</span>
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+                <div class="mt-8 grid gap-2">
+                  <a href="{% url 'home' %}#generator" class="nav-link rounded-md px-3 py-3 hover:bg-[var(--osig-surface-soft)]">Generator</a>
+                  <a href="{% url 'how_to' %}" class="nav-link rounded-md px-3 py-3 hover:bg-[var(--osig-surface-soft)]">Docs</a>
+                  <a href="{% url 'onboarding_wizard' %}" class="nav-link rounded-md px-3 py-3 hover:bg-[var(--osig-surface-soft)]">Wizard</a>
+                  <a href="{% url 'blog_posts' %}" class="nav-link rounded-md px-3 py-3 hover:bg-[var(--osig-surface-soft)]">Guides</a>
+                  <a href="{% url 'pricing' %}" class="nav-link rounded-md px-3 py-3 hover:bg-[var(--osig-surface-soft)]">Pricing</a>
+                  {% if user.is_authenticated %}
+                  <form method="post" action="{% url 'account_logout' %}" class="mt-4 border-t border-[var(--osig-line)] pt-4">
+                    {% csrf_token %}
+                    <button class="btn-secondary w-full" data-action="dropdown#toggle" type="submit">Sign out</button>
+                  </form>
+                  {% else %}
+                  <a href="{% url 'account_signup' %}" class="btn-primary mt-4 w-full">Create image URLs</a>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </nav>
     </header>
 
-    <div class="px-2 sm:px-0">
+    <main>
       {% block content %}
       {% endblock content %}
-    </div>
+    </main>
 
-    <footer class="bg-white">
-      <div class="px-6 py-12 mx-auto max-w-7xl md:flex md:items-center md:justify-between lg:px-8">
-        <div class="mt-8 md:mt-0">
-          <p class="text-xs leading-5 text-center text-gray-500">
-            &copy; 2024 <a href="https://lvtd.dev" target="_blank">LVTD, LLC</a>. All rights reserved.
+    <footer class="mt-20 border-t border-[var(--osig-line)] bg-white/70">
+      <div class="site-container flex flex-col gap-6 py-10 md:flex-row md:items-center md:justify-between">
+        <div>
+          <a href="{% url 'home' %}" class="brand-mark">
+            <img src="{% static 'vendors/images/logo.png' %}" alt="" />
+            <span>OSIG</span>
+          </a>
+          <p class="mt-3 max-w-lg text-sm leading-6 text-[var(--osig-muted)]">
+            Generate social preview images from URLs, signed API calls, and copy-ready metadata.
           </p>
         </div>
-        <div class="text-xs leading-5 text-center text-gray-500">
-          <a href="{% url 'uses' %}" class="text-xs leading-5 text-center text-gray-500 underline">Uses</a>
-          <span aria-hidden="true"> | </span>
-          <a href="https://statushen.com/osig/" class="text-xs leading-5 text-center text-gray-500 underline">Status</a>
+        <div class="flex flex-wrap gap-x-5 gap-y-2 text-sm">
+          <a href="{% url 'how_to' %}" class="nav-link">Docs</a>
+          <a href="{% url 'onboarding_wizard' %}" class="nav-link">Wizard</a>
+          <a href="{% url 'uses' %}" class="nav-link">Uses</a>
+          <a href="https://statushen.com/osig/" class="nav-link">Status</a>
+          <a href="https://github.com/rasulkireev/osig" class="nav-link">GitHub</a>
         </div>
+      </div>
+      <div class="site-container border-t border-[var(--osig-line)] py-5 text-sm text-[var(--osig-soft)]">
+        &copy; 2024 <a href="https://lvtd.dev" target="_blank" rel="noopener noreferrer" class="link">LVTD, LLC</a>. All rights reserved.
       </div>
     </footer>
 

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -26,11 +26,13 @@
 {% endblock meta %}
 
 {% block content %}
-<article class="container px-4 py-8 mx-auto md:relative">
-  <div class="mx-auto max-w-3xl">
-    <h1 class="mb-6 text-3xl font-bold">{{ blog_post.title }}</h1>
+<article class="site-container-narrow py-12 lg:py-16">
+  <div>
+    <a href="{% url 'blog_posts' %}" class="link text-sm">Back to guides</a>
+    <h1 class="section-title mt-4">{{ blog_post.title }}</h1>
+    <p class="lede mt-4">{{ blog_post.description }}</p>
 
-    <div class="prose prose-lg max-w-none">
+    <div class="doc-prose mt-10">
       {{ blog_post.content|markdown|safe }}
     </div>
   </div>

--- a/frontend/templates/blog/blog_posts.html
+++ b/frontend/templates/blog/blog_posts.html
@@ -26,25 +26,27 @@
 {% endblock meta %}
 
 {% block content %}
-<div class="container px-4 py-8 mx-auto md:relative">
-  <div class="mx-auto max-w-3xl">
-    <h1 class="mb-8 text-3xl font-bold text-center">OSIG Blog</h1>
+<section class="site-container-narrow py-12 lg:py-16">
+  <div>
+    <p class="page-kicker">Guides</p>
+    <h1 class="section-title mt-3">Open Graph image guides.</h1>
+    <p class="lede mt-4">Read practical notes about social previews, metadata, and dynamic image generation.</p>
+  </div>
     {% if blog_posts %}
-      <div class="space-y-4">
+      <div class="mt-8 space-y-4">
         {% for post in blog_posts %}
-          <a href="{{ post.get_absolute_url }}" class="block rounded-lg transition duration-150 ease-in-out hover:bg-gray-100">
-            <article class="p-4">
-              <h2 class="mb-2 text-2xl font-semibold text-gray-900">{{ post.title }}</h2>
-              <p class="text-gray-600">{{ post.description }}</p>
+          <a href="{{ post.get_absolute_url }}" class="panel block p-5 transition-colors hover:bg-[var(--osig-surface-soft)]">
+            <article>
+              <h2 class="text-xl font-bold tracking-tight text-[var(--osig-ink)]">{{ post.title }}</h2>
+              <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">{{ post.description }}</p>
             </article>
           </a>
         {% endfor %}
       </div>
     {% else %}
-      <p class="text-center text-gray-600">No blog posts available at the moment.</p>
+      <p class="status-note mt-8">No blog posts are available right now.</p>
     {% endif %}
-  </div>
-</div>
+</section>
 {% endblock content %}
 
 {% block schema %}

--- a/frontend/templates/components/confirm-email.html
+++ b/frontend/templates/components/confirm-email.html
@@ -1,24 +1,16 @@
 {% if not email_verified %}
-<div class="p-4 m-4 mt-8 bg-yellow-50 rounded-md border-2 border-yellow-400">
-  <div class="flex">
-    <div class="flex-shrink-0">
-      <!-- Heroicon name: mini/exclamation-triangle -->
-      <svg class="w-5 h-5 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fill-rule="evenodd" d="M8.485 3.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 3.495zM10 6a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 6zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
-      </svg>
+<div class="mt-8 rounded-lg border border-[var(--osig-warning)] bg-[var(--osig-warning-soft)] p-4">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h2 class="text-sm font-bold text-[var(--osig-ink)]">Confirm your email</h2>
+      <p class="mt-1 text-sm leading-6 text-[var(--osig-muted)]">
+        Some account features stay limited until this email address is confirmed.
+      </p>
     </div>
-    <div class="ml-3">
-      <h3 class="text-sm font-medium text-yellow-800">Attention</h3>
-      <div class="mt-2 text-sm text-yellow-700">
-        <form method="post" action="{{ resend_confirmation_url }}">
-            {% csrf_token %}
-            <p>Your email is not yet confirmed. This will limit the available functionality.</p>
-            <p>You should have gotten a link to confirm in your email. If you haven't received it,
-            <button type="submit" class="inline font-semibold text-yellow-800 underline">click here to resend</button>
-          </form>
-        </p>
-      </div>
-    </div>
+    <form method="post" action="{{ resend_confirmation_url }}">
+      {% csrf_token %}
+      <button type="submit" class="btn-secondary min-h-0 whitespace-nowrap px-3 py-2">Resend email</button>
+    </form>
   </div>
 </div>
 {% endif %}

--- a/frontend/templates/components/messages.html
+++ b/frontend/templates/components/messages.html
@@ -1,21 +1,21 @@
 {% if messages %}
-<div class="fixed top-4 right-4 z-50 space-y-4" data-controller="reveal">
+<div class="fixed right-4 top-4 z-50 max-w-[calc(100vw-2rem)] space-y-3" data-controller="reveal">
   {% for message in messages %}
-  <div data-reveal-target="item" data-message-id="{{ forloop.counter }}" class="rounded-lg border {% if message.tags == 'error' %}bg-red-50 border-red-200{% else %}bg-green-50 border-green-200{% endif %} p-4 shadow-sm transition-all duration-300 ease-in-out opacity-0 transform translate-x-full max-w-sm">
+  <div data-reveal-target="item" data-message-id="{{ forloop.counter }}" class="max-w-sm rounded-lg border {% if message.tags == 'error' %}bg-[var(--osig-danger-soft)] border-[var(--osig-danger)]{% else %}bg-[var(--osig-success-soft)] border-[var(--osig-success)]{% endif %} p-4 transition-all duration-200 ease-out opacity-0 transform translate-x-full">
     <div class="flex items-start">
       <div class="flex-shrink-0 mr-3">
         <svg class="w-5 h-5" viewBox="0 0 24 24">
-          <circle class="text-gray-200" stroke-width="2" stroke="currentColor" fill="transparent" r="10" cx="12" cy="12"/>
+          <circle class="text-[var(--osig-line)]" stroke-width="2" stroke="currentColor" fill="transparent" r="10" cx="12" cy="12"/>
           <circle class="{% if message.tags == 'error' %}text-red-600{% else %}text-green-600{% endif %}" stroke-width="2" stroke="currentColor" fill="transparent" r="10" cx="12" cy="12" data-timer-circle/>
         </svg>
       </div>
       <div class="flex-grow">
-        <p class="text-sm {% if message.tags == 'error' %}text-red-800{% else %}text-green-800{% endif %}">
+        <p class="text-sm font-semibold {% if message.tags == 'error' %}text-[var(--osig-danger)]{% else %}text-[var(--osig-success)]{% endif %}">
           {{ message }}
         </p>
       </div>
       <div class="flex-shrink-0 ml-3">
-        <button data-action="click->reveal#hide" data-message-id="{{ forloop.counter }}" type="button" class="inline-flex justify-center items-center h-5 w-5 rounded-md {% if message.tags == 'error' %}text-red-600 hover:text-red-800{% else %}text-green-600 hover:text-green-800{% endif %} focus:outline-none focus:ring-2 focus:ring-offset-2 {% if message.tags == 'error' %}focus:ring-red-500{% else %}focus:ring-green-500{% endif %}">
+        <button data-action="click->reveal#hide" data-message-id="{{ forloop.counter }}" type="button" class="inline-flex h-5 w-5 items-center justify-center rounded-md {% if message.tags == 'error' %}text-[var(--osig-danger)]{% else %}text-[var(--osig-success)]{% endif %} focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--osig-accent)]">
           <span class="sr-only">Dismiss</span>
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -29,22 +29,31 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const items = document.querySelectorAll('[data-reveal-target="item"]');
     items.forEach((item, index) => {
       setTimeout(() => {
         item.classList.remove('opacity-0', 'translate-x-full');
-        startTimer(item);
+        if (reduceMotion) {
+          item.classList.remove('transform');
+        }
+        startTimer(item, reduceMotion);
       }, index * 100);
     });
   });
 
-  function startTimer(item) {
+  function startTimer(item, reduceMotion) {
     const timerCircle = item.querySelector('[data-timer-circle]');
     const radius = 10;
     const circumference = 2 * Math.PI * radius;
 
     timerCircle.style.strokeDasharray = `${circumference} ${circumference}`;
     timerCircle.style.strokeDashoffset = circumference;
+
+    if (reduceMotion) {
+      setTimeout(() => hideMessage(item), 5000);
+      return;
+    }
 
     let progress = 0;
     const interval = setInterval(() => {

--- a/frontend/templates/pages/home.html
+++ b/frontend/templates/pages/home.html
@@ -2,105 +2,229 @@
 {% load webpack_loader static %}
 
 {% block content %}
-<div class="container px-4 py-8 mx-auto md:relative">
-  <div class="mx-auto max-w-3xl">
-    <h1 class="mb-4 text-3xl font-bold text-center">Generate Open Graph Images for
-      <span class="block text-blue-600">Your Site</span>
-    </h1>
-    <p class="mx-auto max-w-2xl text-base leading-7 text-center text-gray-600">
-      Create branded social preview images for Open Graph and Twitter cards from a shareable URL.
+<section class="site-container grid gap-10 py-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center lg:py-16">
+  <div>
+    <p class="page-kicker">Open Graph image generator</p>
+    <h1 class="page-title mt-4">Generate social preview images from a URL.</h1>
+    <p class="lede mt-6 max-w-2xl">
+      OSIG turns titles, subtitles, logos, and cover images into Open Graph and Twitter card images you can paste into any site.
     </p>
-    <div class="flex flex-col gap-x-6 justify-center items-center mt-10 md:flex-row md:items-end">
-      <a
-        class="block px-3 py-2 text-sm font-semibold text-white bg-blue-600 rounded-md shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-        href="{% url 'account_signup' %}"
-      >
-        Get Started
-      </a>
-      <span class="pb-1 font-bold">or try the generator below</span>
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      <a href="#generator" class="btn-primary">Open generator</a>
+      <a href="{% url 'how_to' %}" class="btn-secondary">Read docs</a>
     </div>
-
-    <div
-      data-controller="image-generator"
-      class="flex flex-col gap-8 mt-10 md:flex-row"
-      data-image-generator-user-key-value="{{ user_key|default:'' }}"
-    >
-      <div class="w-full md:relative md:w-1/2">
-        <form data-action="submit->image-generator#generate" class="space-y-4">
-          {% csrf_token %}
-          <div>
-            <label for="site" class="block mb-1 text-sm font-medium text-gray-700">Size</label>
-            <select id="site" name="site" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-              {% for value, label in site_choices %}
-                <option value="{{ value }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="md:relative">
-            <label for="style" class="block mb-1 text-sm font-medium text-gray-700">Style</label>
-            <select id="style" name="style" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-              {% for value, label in style_choices %}
-                <option value="{{ value }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div class="md:relative">
-            <label for="font" class="block mb-1 text-sm font-medium text-gray-700">Font</label>
-            <select id="font" name="font" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-              {% for value, label in font_choices %}
-                <option value="{{ value }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-          </div>
-
-          <div>
-            <label for="title" class="block mb-1 text-sm font-medium text-gray-700">Title</label>
-            <input type="text" id="title" name="title" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-          </div>
-
-          <div>
-            <label for="subtitle" class="block mb-1 text-sm font-medium text-gray-700">Subtitle</label>
-            <input type="text" id="subtitle" name="subtitle" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-          </div>
-
-          <div>
-            <label for="eyebrow" class="block mb-1 text-sm font-medium text-gray-700">Eyebrow</label>
-            <input type="text" id="eyebrow" name="eyebrow" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-          </div>
-
-          <div>
-            <label for="image_url" class="block mb-1 text-sm font-medium text-gray-700">Background Image URL</label>
-            <input type="url" id="image_url" name="image_url" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-          </div>
-
-          <div>
-            <button type="submit" class="px-4 py-2 w-full text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-              Generate Image
-            </button>
-          </div>
-        </form>
+    <dl class="mt-10 grid gap-4 text-sm sm:grid-cols-3">
+      <div class="border-t border-[var(--osig-line)] pt-4">
+        <dt class="font-bold text-[var(--osig-ink)]">URL based</dt>
+        <dd class="mt-1 text-[var(--osig-muted)]">Works from query parameters, no editor required.</dd>
       </div>
-
-      <div class="w-full md:w-1/2 md:mt-10">
-        <div data-image-generator-target="generatedImage" class="flex overflow-hidden justify-center items-center bg-gray-100 rounded-lg aspect-video">
-          <p class="text-gray-500">Generated image will appear here</p>
-        </div>
-        <div class="mt-4">
-          <label for="generate-link" class="block mb-1 text-sm font-medium text-gray-700">Generated Link</label>
-          <div class="flex flex-col">
-            <textarea id="generate-link" data-image-generator-target="generateLink" readonly class="px-3 py-2 mb-5 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" rows="11"></textarea>
-            <button type="button" data-image-generator-target="copyButton" data-action="click->image-generator#copyGenerateLink" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-              Copy
-            </button>
-          </div>
-        </div>
+      <div class="border-t border-[var(--osig-line)] pt-4">
+        <dt class="font-bold text-[var(--osig-ink)]">Signed output</dt>
+        <dd class="mt-1 text-[var(--osig-muted)]">Generate tamper-proof URLs for production pages.</dd>
       </div>
+      <div class="border-t border-[var(--osig-line)] pt-4">
+        <dt class="font-bold text-[var(--osig-ink)]">Copy-ready</dt>
+        <dd class="mt-1 text-[var(--osig-muted)]">Use the wizard when you need full OG tags.</dd>
+      </div>
+    </dl>
+  </div>
 
+  <div class="panel overflow-hidden">
+    <div class="border-b border-[var(--osig-line)] bg-[var(--osig-surface-soft)] px-4 py-3 text-sm font-semibold text-[var(--osig-muted)]">
+      Generated example
+    </div>
+    <div class="grid gap-4 p-4">
+      <img
+        src="{% static 'vendors/images/base-example.png' %}"
+        class="w-full rounded-lg border border-[var(--osig-line)]"
+        alt="Example OSIG output for an article social preview"
+        width="800"
+        height="450"
+        decoding="async"
+      />
+      <pre class="code-block whitespace-pre-wrap break-all"><code>https://osig.app/g?
+style=base&amp;site=x
+title=10 Years of Great Books</code></pre>
     </div>
   </div>
-</div>
+</section>
+
+<section id="generator" class="site-container py-10">
+  <div class="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="page-kicker">Try it now</p>
+      <h2 class="section-title mt-3">Build the image URL.</h2>
+    </div>
+    <p class="lede max-w-xl">
+      Fill the fields, generate a preview, then copy the URL. Logged-in users automatically include their key.
+    </p>
+  </div>
+
+  <div
+    data-controller="image-generator"
+    class="panel grid gap-0 overflow-hidden lg:grid-cols-[0.95fr_1.05fr]"
+    data-image-generator-user-key-value="{{ user_key|default:'' }}"
+  >
+    <form data-action="submit->image-generator#generate" class="space-y-6 p-5 lg:p-6">
+      {% csrf_token %}
+      <div class="grid gap-4 sm:grid-cols-3">
+        <div>
+          <label for="site" class="field-label">Size</label>
+          <select id="site" name="site" class="field">
+            {% for value, label in site_choices %}
+              <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div>
+          <label for="style" class="field-label">Template</label>
+          <select id="style" name="style" class="field">
+            {% for value, label in style_choices %}
+              <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div>
+          <label for="font" class="field-label">Font</label>
+          <select id="font" name="font" class="field">
+            {% for value, label in font_choices %}
+              <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div class="sm:col-span-2">
+          <label for="title" class="field-label">Title</label>
+          <input type="text" id="title" name="title" class="field" placeholder="Hiring: Senior Django Engineer">
+        </div>
+
+        <div class="sm:col-span-2">
+          <label for="subtitle" class="field-label">Subtitle</label>
+          <input type="text" id="subtitle" name="subtitle" class="field" placeholder="Build reliable product features and own the roadmap.">
+        </div>
+
+        <div>
+          <label for="eyebrow" class="field-label">Eyebrow</label>
+          <input type="text" id="eyebrow" name="eyebrow" class="field" placeholder="Remote · Full-time">
+        </div>
+
+        <div>
+          <label for="image_url" class="field-label">Image or logo URL</label>
+          <input type="url" id="image_url" name="image_url" class="field" placeholder="https://example.com/logo.png">
+        </div>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-3">
+        <div>
+          <label for="format" class="field-label">Format</label>
+          <select id="format" name="format" class="field">
+            <option value="png">PNG</option>
+            <option value="jpeg">JPEG</option>
+          </select>
+        </div>
+        <div>
+          <label for="quality" class="field-label">JPEG quality</label>
+          <input type="number" id="quality" name="quality" class="field" min="1" max="100" placeholder="85">
+        </div>
+        <div>
+          <label for="max_kb" class="field-label">Max KB</label>
+          <input type="number" id="max_kb" name="max_kb" class="field" min="1" placeholder="Optional">
+        </div>
+      </div>
+
+      <button type="submit" class="btn-primary w-full">Generate image</button>
+    </form>
+
+    <div class="border-t border-[var(--osig-line)] bg-[var(--osig-surface-soft)] p-5 lg:border-l lg:border-t-0 lg:p-6">
+      <div class="sticky top-24 space-y-5">
+        <div>
+          <div class="mb-2 flex items-center justify-between gap-3">
+            <label class="field-label mb-0">Preview</label>
+            <span data-image-generator-target="status" class="text-xs font-semibold text-[var(--osig-soft)]">Ready</span>
+          </div>
+          <div data-image-generator-target="generatedImage" class="preview-frame">
+            <div class="px-6 text-center">
+              <p class="font-semibold text-[var(--osig-ink)]">Generated image appears here.</p>
+              <p class="mt-2 text-sm text-[var(--osig-muted)]">Use a title and template first, then generate a preview.</p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <label for="generate-link" class="field-label">Generated URL</label>
+          <textarea id="generate-link" data-image-generator-target="generateLink" readonly class="copy-field" rows="10"></textarea>
+          <button type="button" data-image-generator-target="copyButton" data-action="click->image-generator#copyGenerateLink" class="btn-secondary mt-3 w-full">
+            Copy URL
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="site-container grid gap-8 py-12 lg:grid-cols-[0.8fr_1.2fr] lg:py-16">
+  <div>
+    <p class="page-kicker">Publishing path</p>
+    <h2 class="section-title mt-3">From blank metadata to validated preview.</h2>
+  </div>
+  <div class="grid gap-4 md:grid-cols-3">
+    <div class="panel p-5">
+      <span class="step-pill">1</span>
+      <h3 class="mt-5 text-lg font-bold">Choose content</h3>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Add the title, subtitle, image, logo, and template that match the page.</p>
+    </div>
+    <div class="panel p-5">
+      <span class="step-pill">2</span>
+      <h3 class="mt-5 text-lg font-bold">Generate URL</h3>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Copy a direct image URL or use the wizard to create signed metadata.</p>
+    </div>
+    <div class="panel p-5">
+      <span class="step-pill">3</span>
+      <h3 class="mt-5 text-lg font-bold">Validate share</h3>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Open social validators before publishing so cached previews behave.</p>
+    </div>
+  </div>
+</section>
+
+<section class="site-container py-12">
+  <div class="grid gap-8 lg:grid-cols-2 lg:items-start">
+    <div>
+      <p class="page-kicker">Template examples</p>
+      <h2 class="section-title mt-3">Use images for articles, jobs, products, and company pages.</h2>
+      <p class="lede mt-5">
+        The same endpoint supports multiple styles and fonts. Start with the generator when you need one image, or use signed API output for repeatable publishing.
+      </p>
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+        <a href="{% url 'onboarding_wizard' %}" class="btn-primary">Create OG tags</a>
+        <a href="{% url 'how_to' %}#parameters" class="btn-secondary">View parameters</a>
+      </div>
+    </div>
+    <div class="grid gap-4">
+      <img
+        src="{% static 'vendors/images/logo-example.png' %}"
+        class="w-full rounded-lg border border-[var(--osig-line)]"
+        alt="Example OSIG logo template output"
+        width="796"
+        height="445"
+        loading="lazy"
+        decoding="async"
+      />
+      <img
+        src="{% static 'vendors/images/no-params-example.png' %}"
+        class="w-full rounded-lg border border-[var(--osig-line)]"
+        alt="Example OSIG output when no parameters are supplied"
+        width="797"
+        height="447"
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
+  </div>
+</section>
 
 {% if show_confetti %}
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>

--- a/frontend/templates/pages/how-to.html
+++ b/frontend/templates/pages/how-to.html
@@ -26,92 +26,160 @@
 {% endblock meta %}
 
 {% block content %}
-<div class="container px-4 py-8 mx-auto md:relative">
-  <div class="mx-auto max-w-3xl">
-    <h1 class="mb-8 text-3xl font-bold text-center">OG Image Generator
-    <span class="block text-blue-600">Documentation</span>
-    </h1>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Overview</h2>
-      <p class="mb-4">The OG Image Generator allows you to create custom Open Graph images for your website. You can specify various parameters to customize the image according to your needs.</p>
+<section class="site-container grid gap-8 py-12 lg:grid-cols-[0.75fr_1.25fr] lg:py-16">
+  <aside class="hidden lg:block">
+    <div class="sticky top-24 space-y-2 text-sm">
+      <a href="#endpoint" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Endpoint</a>
+      <a href="#parameters" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Parameters</a>
+      <a href="#examples" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Examples</a>
+      <a href="#output-controls" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Output controls</a>
+      <a href="#signed-urls" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Signed URLs</a>
+      <a href="#mcp" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Using the MCP</a>
+      <a href="#meta-tags" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Meta tags</a>
+      <a href="#validation" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Validation</a>
     </div>
+  </aside>
 
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">URL</h2>
-      <p class="mb-4">The url for all images will be the same:</p>
-      <code class="block p-4 bg-gray-100 rounded-md">
-        https://osig.app/g/
-      </code>
-    </div>
+  <div class="min-w-0">
+    <p class="page-kicker">Docs</p>
+    <h1 class="page-title mt-4">Publish OG images.</h1>
+    <p class="lede mt-6 max-w-3xl">
+      Use the generator for one image, or call the endpoint directly from your site. Most previews need a title, subtitle, template, and optional image URL.
+    </p>
 
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Parameters</h2>
-      <p class="mb-4">Parameters vary by style. All of them are optional, but a title and subtitle usually produce a better preview.</p>
+    <div class="doc-prose mt-10">
+      <h2 id="endpoint">Endpoint</h2>
+      <p>All generated images are served from the same endpoint.</p>
+      <pre class="code-block"><code>https://osig.app/g</code></pre>
 
+      <h2 id="parameters">Parameters</h2>
+      <p>Parameters vary by template. Empty values still render, but useful text and an image source usually produce a better preview.</p>
+
+      <div class="not-prose overflow-x-auto rounded-lg border border-[var(--osig-line)] bg-white">
+        <table class="min-w-full divide-y divide-[var(--osig-line)] text-left text-sm">
+          <thead class="bg-[var(--osig-surface-soft)] text-[var(--osig-muted)]">
+            <tr>
+              <th class="px-4 py-3 font-bold">Name</th>
+              <th class="px-4 py-3 font-bold">Use</th>
+              <th class="px-4 py-3 font-bold">Common values</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[var(--osig-line)] text-[var(--osig-muted)]">
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">style</td>
+              <td class="px-4 py-3">Template to render.</td>
+              <td class="px-4 py-3">base, logo, job_classic, job_logo, job_clean</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">site</td>
+              <td class="px-4 py-3">Output dimensions.</td>
+              <td class="px-4 py-3">x: 1600 x 900, meta: 1200 x 630</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">font</td>
+              <td class="px-4 py-3">Font used for image text.</td>
+              <td class="px-4 py-3">helvetica, markerfelt, papyrus</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">title</td>
+              <td class="px-4 py-3">Main headline.</td>
+              <td class="px-4 py-3">Article title, job title, product name</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">subtitle</td>
+              <td class="px-4 py-3">Supporting text, truncated when needed.</td>
+              <td class="px-4 py-3">Summary, role detail, short description</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">eyebrow</td>
+              <td class="px-4 py-3">Small context label inside the generated image.</td>
+              <td class="px-4 py-3">Article, Remote, Launch, Guide</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">image_url</td>
+              <td class="px-4 py-3">Background image or logo URL.</td>
+              <td class="px-4 py-3">Public image URL</td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 font-mono text-[var(--osig-ink)]">key</td>
+              <td class="px-4 py-3">Authenticated profile key from settings.</td>
+              <td class="px-4 py-3">Your OSIG token</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="examples">Examples</h2>
+
+      <h3 id="base">Base style</h3>
+      <p>Use the base style for articles, tutorials, essays, and general pages that have a strong cover image.</p>
       <img
-        src="{% static 'vendors/images/no-params-example.png' %}"
-        class="mb-4 rounded-md"
-        alt="OG Image Generator Parameters"
-        width="797"
-        height="447"
+        src="{% static 'vendors/images/base-example.png' %}"
+        alt="Base OG image example"
+        width="800"
+        height="450"
         loading="lazy"
         decoding="async"
       />
+      <pre class="code-block"><code>https://osig.app/g?
+  site=x
+  &amp;style=base
+  &amp;font=helvetica
+  &amp;title=10 Years of Great Books
+  &amp;subtitle=I'm starting a 10 Year Reading Plan.
+  &amp;eyebrow=Article
+  &amp;image_url=https://example.com/cover.png</code></pre>
 
-      <p class="mb-4">Below is a list of all parameters we currently support:</p>
+      <h3 id="logo">Logo style</h3>
+      <p>Use the logo style for companies, projects, job posts, and pages where a brand mark matters more than a full background image.</p>
+      <img
+        src="{% static 'vendors/images/logo-example.png' %}"
+        alt="Logo OG image example"
+        width="796"
+        height="445"
+        loading="lazy"
+        decoding="async"
+      />
+      <pre class="code-block"><code>https://osig.app/g?
+  site=x
+  &amp;style=logo
+  &amp;font=markerfelt
+  &amp;title=Narrative
+  &amp;subtitle=Founding Senior Software Engineer
+  &amp;image_url=https://example.com/logo.png</code></pre>
 
-      <ul class="space-y-2 list-disc list-inside">
-        <li><strong>key</strong>: Your API key. Can be found in your <a href="{% url 'settings' %}" class="text-blue-500 underline">settings</a> page, if you are registered.</li>
-        <li>
-          <strong>style</strong>: Image style (default: "base")
-          <ul class="mt-2 ml-6 space-y-1">
-            <li>- <a class="link" href="#base">base</a></li>
-            <li>- <a class="link" href="#logo">logo</a></li>
-          </ul>
-        </li>
-        <li>
-          <strong>site</strong>: This dictates the size of the image (default: "x")
-          <ul class="mt-2 ml-6 space-y-1">
-            <li>- x (1600 by 900)</li>
-            <li>- meta (1200 by 630)</li>
-          </ul>
-        </li>
-        <li>
-          <strong>font</strong>: Font to use for text (more will be added)
-          <ul class="mt-2 ml-6 space-y-1">
-            <li>- <a class="link" href="#Helvetica">helvetica</a></li>
-            <li>- <a class="link" href="#Markerfelt">markerfelt</a></li>
-            <li>- <a class="link" href="#Papyrus">papyrus</a></li>
-          </ul>
-        </li>
-        <li><strong>title</strong>: Main title text</li>
-        <li><strong>subtitle</strong>: Subtitle text</li>
-        <li><strong>eyebrow</strong>: Eyebrow text</li>
-        <li><strong>image_url</strong>: URL of the background image</li>
+      <h2 id="output-controls">Output controls</h2>
+      <p>Use output controls when your publishing platform needs JPEG output or a smaller file.</p>
+      <ul>
+        <li><strong>format</strong>: png or jpeg. The default is png.</li>
+        <li><strong>quality</strong>: 1 to 100. JPEG defaults to 85 when omitted.</li>
+        <li><strong>max_kb</strong>: best-effort file size target, currently tuned for JPEG.</li>
+        <li><strong>v</strong>: cache-busting version token. Change this when preview content changes.</li>
       </ul>
-    </div>
 
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Usage</h2>
-      <p class="mb-4">The url for all images will be the same:</p>
-      <pre><code class="block p-4 bg-gray-100 rounded-md">&lt;meta name="twitter:card" content="summary_large_image" /&gt;
-&lt;meta name="twitter:image" content="{ generated_image_url }"/&gt;</code></pre>
-    </div>
+      <h2 id="signed-urls">Signed URLs</h2>
+      <p>Signed URLs protect generated previews from tampering. Send the desired image parameters to the signing endpoint and embed the returned URL.</p>
+      <pre class="code-block"><code>POST /api/sign
+{
+  "params": {
+    "style": "logo",
+    "site": "x",
+    "title": "Narrative",
+    "format": "jpeg",
+    "quality": 80
+  },
+  "expires_in_seconds": 3600
+}</code></pre>
 
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Using the MCP</h2>
-      <p class="mb-4">OSIG also exposes a Model Context Protocol server for agent clients that need to inspect image options, render previews, and build signed image URLs.</p>
-
-      <ol class="space-y-3 list-decimal list-inside">
-        <li><strong>Get your profile key</strong> from the <a href="{% url 'settings' %}" class="text-blue-500 underline">settings</a> page.</li>
-        <li><strong>Connect your MCP client</strong> to the hosted Streamable HTTP endpoint: <code class="px-1 py-0.5 bg-gray-100 rounded">https://osig.app/mcp/</code></li>
-        <li><strong>Authenticate requests</strong> with either <code class="px-1 py-0.5 bg-gray-100 rounded">X-API-Key: &lt;profile-key&gt;</code> or <code class="px-1 py-0.5 bg-gray-100 rounded">Authorization: Bearer &lt;profile-key&gt;</code>.</li>
-        <li><strong>Start with <code>get_image_generation_contract</code></strong> to see the available styles, fields, dimensions, and recommended workflow.</li>
+      <h2 id="mcp">Using the MCP</h2>
+      <p>OSIG exposes a Model Context Protocol server for agent clients that need to inspect options, render previews, and build signed image URLs.</p>
+      <ol>
+        <li>Get your profile key from the <a class="link" href="{% url 'settings' %}">settings page</a>.</li>
+        <li>Connect your MCP client to <code>https://osig.app/mcp/</code>.</li>
+        <li>Authenticate with <code>X-API-Key: &lt;profile-key&gt;</code> or <code>Authorization: Bearer &lt;profile-key&gt;</code>.</li>
+        <li>Call <code>get_image_generation_contract</code> first to inspect styles, fields, dimensions, and the recommended workflow.</li>
       </ol>
-
-      <p class="mt-4 mb-4">If your MCP client accepts a JSON-style server definition, the hosted connection looks like this:</p>
-      <pre class="block overflow-x-auto p-4 bg-gray-100 rounded-md"><code>{
+      <pre class="code-block"><code>{
   "mcpServers": {
     "osig": {
       "url": "https://osig.app/mcp/",
@@ -121,143 +189,69 @@
     }
   }
 }</code></pre>
+      <p>A useful agent workflow is to normalize parameters, render previews while iterating, build a signed URL, then place that URL in your Open Graph and Twitter image tags.</p>
+      <pre class="code-block"><code>normalize_image_params
+render_image_preview
+build_signed_image_url</code></pre>
+      <p>For local development with this repository checked out, run the stdio server.</p>
+      <pre class="code-block"><code>uv run python mcp_server.py</code></pre>
 
-      <p class="mt-4 mb-4">A good agent workflow is:</p>
-      <ul class="space-y-2 list-disc list-inside">
-        <li>Call <code>normalize_image_params</code> to canonicalize style, font, size, and text fields.</li>
-        <li>Call <code>render_image_preview</code> while iterating on title, subtitle, eyebrow, and image URL.</li>
-        <li>Call <code>build_signed_image_url</code> when the preview is ready to publish.</li>
-        <li>Use the signed URL in your Open Graph and Twitter image tags.</li>
-      </ul>
+      <h2 id="meta-tags">Meta tags</h2>
+      <p>Use the generated image URL in Open Graph and Twitter card metadata.</p>
+      <pre class="code-block"><code>&lt;meta property="og:image" content="{ generated_image_url }" /&gt;
+&lt;meta name="twitter:card" content="summary_large_image" /&gt;
+&lt;meta name="twitter:image" content="{ generated_image_url }" /&gt;</code></pre>
 
-      <p class="mt-4 mb-4">For local development with the repository checked out, run the stdio server instead:</p>
-      <pre class="block overflow-x-auto p-4 bg-gray-100 rounded-md"><code>uv run python mcp_server.py</code></pre>
-    </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Examples</h2>
-
-      <h3 id="base" class="pb-2 text-2xl font-semibold">Base Style</h3>
-      <p class="mb-4">This is useful for general pages like Articles, Tutorial, News pages. Pro tip, you can generate the background image using AI. Those work super well.</p>
-      <p class="mb-4">Here is what gets generated for my site's articles:</p>
-      <img
-      src="{% static 'vendors/images/base-example.png' %}"
-      class="mb-4 rounded-md"
-      alt="Base OG Image Example"
-      width="800"
-      height="450"
-      loading="lazy"
-      decoding="async"
-      />
-
-      <p class="mb-4">This is the URL that generates the image:</p>
-      <pre class="block overflow-x-auto p-4 bg-gray-100 rounded-md"><code>https://osig.app/g?
-  site=x
-  &style=base
-  &font=helvetica
-  &title=10 Years of Great Books
-  &subtitle=I'm starting a 10 Year Reading Plan proposed in the 1st Volume (The Great Conversation) of the "Great Books of the Western World" series.
-  &eyebrow=Article
-  &image_url=https://www.rasulkireev.com/_astro/a_smiling_boy_from_Pixars_Coco.DrP3G0Ol.png</code></pre>
-
-      <h3 id="logo" class="pb-2 mt-6 text-2xl font-semibold">Logo Style</h3>
-      <p class="mb-4">Logo style is useful when you want to highlight a company, a project, a job posting, or another branded page.</p>
-      <p class="mb-4">Here is how I use it for one of my job boards:</p>
-      <img
-        src="{% static 'vendors/images/logo-example.png' %}"
-        class="mb-4 rounded-md"
-        alt="Logo OG Image Example"
-        width="796"
-        height="445"
-        loading="lazy"
-        decoding="async"
-      />
-
-      <p class="mb-4">This is the URL that generates the image:</p>
-      <pre class="block overflow-x-auto p-4 bg-gray-100 rounded-md"><code>https://osig.app/g?
-  site=x
-  &style=logo
-  &font=markerfelt
-  &title=Narrative
-  &subtitle=Founding Senior Software Engineer
-  &image_url=http://res.cloudinary.com/built-with-django/image/upload/v1728024021/user-profile-image-prod/hhxfplsthiaytuttoamc.jpg</code></pre>
-    </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Fonts</h2>
-      <ul class="space-y-2 list-disc list-inside">
-        <li id="Helvetica">
-          Helvetica
+      <h2>Fonts</h2>
+      <div class="not-prose grid gap-4 sm:grid-cols-3">
+        <div class="panel p-4">
+          <p class="mb-3 text-sm font-bold text-[var(--osig-ink)]">Helvetica</p>
           <img
             src="{% static 'vendors/images/helvetica-example.png' %}"
-            class="mb-4 rounded-md"
-            alt="Helvetica Font Example"
+            alt="Helvetica font example"
             width="365"
             height="96"
             loading="lazy"
             decoding="async"
           />
-        </li>
-        <li id="Markerfelt">
-          Markerfelt
+        </div>
+        <div class="panel p-4">
+          <p class="mb-3 text-sm font-bold text-[var(--osig-ink)]">Marker Felt</p>
           <img
             src="{% static 'vendors/images/markerfelt-example.png' %}"
-            class="mb-4 rounded-md"
-            alt="Markerfelt Font Example"
+            alt="Marker Felt font example"
             width="362"
             height="98"
             loading="lazy"
             decoding="async"
           />
-        </li>
-        <li id="Papyrus">
-          Papyrus
+        </div>
+        <div class="panel p-4">
+          <p class="mb-3 text-sm font-bold text-[var(--osig-ink)]">Papyrus</p>
           <img
             src="{% static 'vendors/images/papyrus-example.png' %}"
-            class="mb-4 rounded-md"
-            alt="Papyrus Font Example"
+            alt="Papyrus font example"
             width="276"
             height="88"
             loading="lazy"
             decoding="async"
           />
-        </li>
+        </div>
+      </div>
+
+      <h2 id="validation">Validation checklist</h2>
+      <ul>
+        <li>Bump <strong>v</strong> when image content changes.</li>
+        <li>Regenerate a signed URL if signed parameters changed.</li>
+        <li>Deploy metadata with the new image URL.</li>
+        <li>Open social validators before sharing the page.</li>
       </ul>
+      <p>
+        Start with the <a class="link" href="{% url 'onboarding_wizard' %}">onboarding wizard</a> when you want OSIG to generate meta tags and validation links for you.
+      </p>
     </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Precautions</h2>
-      <p>Once you insert this link on your site, make sure to test it before sharing links online. I like to use <a class="link" href="https://threadcreator.com/tools/twitter-card-validator">this Twitter Card Validator</a></p>
-    </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Notes</h2>
-      <ul class="space-y-2 list-disc list-inside">
-        <li>Subtitle text is truncated to 150 characters if longer.</li>
-        <li>You can remove the watermark by subscribing to the <a class="link" href="{% url 'pricing' %}">PRO version</a>.</li>
-      </ul>
-    </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">Integrating into your Site</h2>
-      <p>As people use this, I will start adding more specific instructions on how to add these to your specific site that might use different technologies:</p>
-      <ul class="mt-4 space-y-2 list-disc list-inside">
-        <li>Wordpress</li>
-        <li>Django</li>
-        <li>Astro</li>
-        <li>Ruby on Rails</li>
-        <li>Next.js</li>
-        <li>etc.</li>
-      </ul>
-    </div>
-
-    <div class="mt-10">
-      <h2 class="pb-2 my-4 text-3xl font-semibold border-b border-gray-200">API</h2>
-      <p>I will be adding more instruction on how you can generate those images programmatically via an API soon.</p>
-    </div>
-
   </div>
-</div>
+</section>
 {% endblock content %}
 
 {% block schema %}

--- a/frontend/templates/pages/onboarding-wizard.html
+++ b/frontend/templates/pages/onboarding-wizard.html
@@ -2,139 +2,192 @@
 {% load webpack_loader static %}
 
 {% block content %}
-<div class="container px-4 py-8 mx-auto">
-  <div class="mx-auto max-w-3xl" data-controller="onboarding-wizard">
-    <h1 class="mb-3 text-3xl font-bold text-center">OG Image Onboarding Wizard</h1>
-    <p class="mb-8 text-center text-gray-600">Go from blank form to publish-ready OG meta tags in 5 steps.</p>
+<section class="site-container py-12 lg:py-16" data-controller="onboarding-wizard">
+  <div class="mb-8 grid gap-6 lg:grid-cols-[0.9fr_1.1fr] lg:items-end">
+    <div>
+      <p class="page-kicker">Onboarding wizard</p>
+      <h1 class="page-title mt-4">Create signed OG tags in five steps.</h1>
+    </div>
+    <p class="lede">
+      Use this flow when you need the image URL, Open Graph tags, Twitter tags, and validator links together.
+    </p>
+  </div>
 
-    <form data-onboarding-wizard-target="wizardForm" class="space-y-6" novalidate>
-      <section data-onboarding-wizard-target="step" class="space-y-4">
-        <h2 class="text-xl font-semibold">Step 1 · Content destination</h2>
+  <div class="panel grid overflow-hidden lg:grid-cols-[18rem_1fr]">
+    <aside class="border-b border-[var(--osig-line)] bg-[var(--osig-surface-soft)] p-4 lg:border-b-0 lg:border-r">
+      <div class="grid grid-cols-2 gap-2 sm:grid-cols-5 lg:grid-cols-1">
+        <div data-onboarding-wizard-target="progressItem" class="wizard-step-indicator">
+          <span class="step-pill">1</span>
+          <span>Destination</span>
+        </div>
+        <div data-onboarding-wizard-target="progressItem" class="wizard-step-indicator">
+          <span class="step-pill">2</span>
+          <span>Copy</span>
+        </div>
+        <div data-onboarding-wizard-target="progressItem" class="wizard-step-indicator">
+          <span class="step-pill">3</span>
+          <span>Template</span>
+        </div>
+        <div data-onboarding-wizard-target="progressItem" class="wizard-step-indicator">
+          <span class="step-pill">4</span>
+          <span>Output</span>
+        </div>
+        <div data-onboarding-wizard-target="progressItem" class="wizard-step-indicator">
+          <span class="step-pill">5</span>
+          <span>Generate</span>
+        </div>
+      </div>
+      <p class="mt-6 hidden text-sm leading-6 text-[var(--osig-muted)] lg:block">
+        Required fields are checked before the final API call, so you can move through the setup quickly.
+      </p>
+    </aside>
+
+    <form data-onboarding-wizard-target="wizardForm" class="p-5 lg:p-7" novalidate>
+      <section data-onboarding-wizard-target="step" class="space-y-5">
         <div>
-          <label for="page_url" class="block mb-1 text-sm font-medium text-gray-700">Canonical page URL</label>
-          <input id="page_url" data-onboarding-wizard-target="pageUrl" type="url" placeholder="https://example.com/job-offer" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <h2 class="text-2xl font-bold tracking-tight">Where will this preview appear?</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Use the canonical URL of the page that will contain these tags.</p>
+        </div>
+        <div>
+          <label for="page_url" class="field-label">Canonical page URL</label>
+          <input id="page_url" data-onboarding-wizard-target="pageUrl" type="url" placeholder="https://example.com/job-offer" class="field" />
         </div>
         <div class="flex justify-end">
-          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="btn-primary">Continue to copy</button>
         </div>
       </section>
 
-      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
-        <h2 class="text-xl font-semibold">Step 2 · Core OG copy</h2>
+      <section data-onboarding-wizard-target="step" class="hidden space-y-5">
         <div>
-          <label for="title" class="block mb-1 text-sm font-medium text-gray-700">Title</label>
-          <input id="title" data-onboarding-wizard-target="title" type="text" placeholder="Hiring: Senior Backend Engineer" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <h2 class="text-2xl font-bold tracking-tight">Write the social preview copy.</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Keep the title direct. Use the subtitle for context that helps someone decide to click.</p>
         </div>
         <div>
-          <label for="subtitle" class="block mb-1 text-sm font-medium text-gray-700">Subtitle</label>
-          <textarea id="subtitle" data-onboarding-wizard-target="subtitle" rows="3" placeholder="Build reliable services with Django + Postgres." class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"></textarea>
+          <label for="title" class="field-label">Title</label>
+          <input id="title" data-onboarding-wizard-target="title" type="text" placeholder="Hiring: Senior Backend Engineer" class="field" />
         </div>
         <div>
-          <label for="eyebrow" class="block mb-1 text-sm font-medium text-gray-700">Eyebrow</label>
-          <input id="eyebrow" data-onboarding-wizard-target="eyebrow" type="text" placeholder="Remote · Full-time" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
+          <label for="subtitle" class="field-label">Subtitle</label>
+          <textarea id="subtitle" data-onboarding-wizard-target="subtitle" rows="3" placeholder="Build reliable services with Django and Postgres." class="field"></textarea>
         </div>
-        <div class="flex justify-between">
-          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
-          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        <div>
+          <label for="eyebrow" class="field-label">Eyebrow</label>
+          <input id="eyebrow" data-onboarding-wizard-target="eyebrow" type="text" placeholder="Remote · Full-time" class="field" />
+        </div>
+        <div class="flex justify-between gap-3">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="btn-secondary">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="btn-primary">Continue to template</button>
         </div>
       </section>
 
-      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
-        <h2 class="text-xl font-semibold">Step 3 · Image & template</h2>
+      <section data-onboarding-wizard-target="step" class="hidden space-y-5">
         <div>
-          <label for="site" class="block mb-1 text-sm font-medium text-gray-700">Social image size</label>
-          <select id="site" data-onboarding-wizard-target="site" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-            <option value="x">X / Twitter (1600 x 900)</option>
-            <option value="meta">Meta (1200 x 630)</option>
-          </select>
+          <h2 class="text-2xl font-bold tracking-tight">Choose the image shape.</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Pick the target network size, template, font, and optional image source.</p>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-3">
+          <div>
+            <label for="site" class="field-label">Social image size</label>
+            <select id="site" data-onboarding-wizard-target="site" class="field">
+              <option value="x">X / Twitter (1600 x 900)</option>
+              <option value="meta">Meta (1200 x 630)</option>
+            </select>
+          </div>
+          <div>
+            <label for="style" class="field-label">Template</label>
+            <select id="style" data-onboarding-wizard-target="style" class="field">
+              <option value="base">Base</option>
+              <option value="logo">Logo</option>
+              <option value="job_classic">Job Classic</option>
+              <option value="job_logo">Job Logo</option>
+              <option value="job_clean">Job Clean</option>
+            </select>
+          </div>
+          <div>
+            <label for="font" class="field-label">Font</label>
+            <select id="font" data-onboarding-wizard-target="font" class="field">
+              <option value="helvetica">Helvetica</option>
+              <option value="markerfelt">Marker Felt</option>
+              <option value="papyrus">Papyrus</option>
+            </select>
+          </div>
         </div>
         <div>
-          <label for="style" class="block mb-1 text-sm font-medium text-gray-700">Style</label>
-          <select id="style" data-onboarding-wizard-target="style" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-            <option value="base">Base</option>
-            <option value="logo">Logo</option>
-            <option value="job_classic">Job Classic</option>
-            <option value="job_logo">Job Logo</option>
-            <option value="job_clean">Job Clean</option>
-          </select>
+          <label for="image_url" class="field-label">Image or logo URL</label>
+          <input id="image_url" data-onboarding-wizard-target="imageUrl" type="url" placeholder="https://example.com/logo-or-cover.png" class="field" />
+          <p class="field-help">Job templates can use a company logo or a brand image in this field.</p>
         </div>
-        <div>
-          <label for="font" class="block mb-1 text-sm font-medium text-gray-700">Font</label>
-          <select id="font" data-onboarding-wizard-target="font" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-            <option value="helvetica">Helvetica</option>
-            <option value="markerfelt">Marker Felt</option>
-            <option value="papyrus">Papyrus</option>
-          </select>
-        </div>
-        <div>
-          <label for="image_url" class="block mb-1 text-sm font-medium text-gray-700">Image / logo URL</label>
-          <input id="image_url" data-onboarding-wizard-target="imageUrl" type="url" placeholder="https://example.com/logo-or-cover.png" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
-          <p class="mt-1 text-sm text-gray-500">For job styles you can pass a logo or brand image in this field.</p>
-        </div>
-        <div class="flex justify-between">
-          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
-          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        <div class="flex justify-between gap-3">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="btn-secondary">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="btn-primary">Continue to output</button>
         </div>
       </section>
 
-      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
-        <h2 class="text-xl font-semibold">Step 4 · Output controls</h2>
+      <section data-onboarding-wizard-target="step" class="hidden space-y-5">
         <div>
-          <label for="format" class="block mb-1 text-sm font-medium text-gray-700">Output format</label>
-          <select id="format" data-onboarding-wizard-target="format" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-            <option value="png">PNG</option>
-            <option value="jpeg">JPEG</option>
-          </select>
+          <h2 class="text-2xl font-bold tracking-tight">Set output controls.</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Use defaults unless your publishing system needs a specific file type or size.</p>
         </div>
-        <div>
-          <label for="quality" class="block mb-1 text-sm font-medium text-gray-700">JPEG quality (1-100)</label>
-          <input id="quality" data-onboarding-wizard-target="quality" type="number" min="1" max="100" placeholder="85" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
-          <p class="mt-1 text-sm text-gray-500">Only used when format = JPEG. Leave blank to use default quality.</p>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label for="format" class="field-label">Output format</label>
+            <select id="format" data-onboarding-wizard-target="format" class="field">
+              <option value="png">PNG</option>
+              <option value="jpeg">JPEG</option>
+            </select>
+          </div>
+          <div>
+            <label for="quality" class="field-label">JPEG quality</label>
+            <input id="quality" data-onboarding-wizard-target="quality" type="number" min="1" max="100" placeholder="85" class="field" />
+            <p class="field-help">Only used for JPEG output.</p>
+          </div>
+          <div>
+            <label for="max_kb" class="field-label">Max KB</label>
+            <input id="max_kb" data-onboarding-wizard-target="maxKb" type="number" min="1" placeholder="Optional" class="field" />
+            <p class="field-help">Best-effort size target.</p>
+          </div>
+          <div>
+            <label for="version" class="field-label">Cache version</label>
+            <input id="version" data-onboarding-wizard-target="version" type="text" placeholder="v2026-06-05" class="field" />
+            <p class="field-help">Change this when preview content changes.</p>
+          </div>
         </div>
-        <div>
-          <label for="max_kb" class="block mb-1 text-sm font-medium text-gray-700">Max KB (optional)</label>
-          <input id="max_kb" data-onboarding-wizard-target="maxKb" type="number" min="1" placeholder="0" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
-          <p class="mt-1 text-sm text-gray-500">Optional size target for signed image generation.</p>
-        </div>
-        <div>
-          <label for="version" class="block mb-1 text-sm font-medium text-gray-700">Cache version</label>
-          <input id="version" data-onboarding-wizard-target="version" type="text" placeholder="e.g. v2026" class="px-3 py-2 w-full rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" />
-          <p class="mt-1 text-sm text-gray-500">Update this value when source content changes to bust cached image URLs.</p>
-        </div>
-        <div class="flex justify-between">
-          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
-          <button type="button" data-action="onboarding-wizard#goNext" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Next</button>
+        <div class="flex justify-between gap-3">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="btn-secondary">Back</button>
+          <button type="button" data-action="onboarding-wizard#goNext" class="btn-primary">Review and generate</button>
         </div>
       </section>
 
-      <section data-onboarding-wizard-target="step" class="hidden space-y-4">
-        <h2 class="text-xl font-semibold">Step 5 · Generate</h2>
-        <p class="text-sm text-gray-600">Sign your image URL, get ready-to-copy OG tags, and open validator links.</p>
+      <section data-onboarding-wizard-target="step" class="hidden space-y-5">
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight">Generate signed metadata.</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">This creates a signed image URL, copy-ready tags, and links to social preview validators.</p>
+        </div>
 
-        <button type="button" data-action="onboarding-wizard#generate" class="px-4 py-2 text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Generate OG meta</button>
+        <button type="button" data-action="onboarding-wizard#generate" class="btn-primary">Generate OG tags</button>
 
-        <div class="mt-2">
-          <label for="meta_tags" class="block mb-1 text-sm font-medium text-gray-700">Copy-ready meta tags</label>
-          <textarea id="meta_tags" data-onboarding-wizard-target="metaTags" rows="12" readonly class="px-3 py-2 w-full rounded-md border border-gray-200 bg-gray-50 font-mono text-sm" placeholder="Generated tags will appear here"></textarea>
-          <div class="mt-3 flex gap-2">
-            <button type="button" data-action="onboarding-wizard#copyMetaTags" class="px-4 py-2 text-white bg-gray-800 rounded-md hover:bg-gray-900">Copy</button>
-            <a href="#" data-onboarding-wizard-target="previewLink" target="_blank" rel="noopener" class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100">Preview image</a>
+        <div>
+          <label for="meta_tags" class="field-label">Copy-ready meta tags</label>
+          <textarea id="meta_tags" data-onboarding-wizard-target="metaTags" rows="12" readonly class="copy-field" placeholder="Generated tags will appear here"></textarea>
+          <div class="mt-3 flex flex-col gap-3 sm:flex-row">
+            <button type="button" data-action="onboarding-wizard#copyMetaTags" class="btn-secondary">Copy meta tags</button>
+            <a href="#" data-onboarding-wizard-target="previewLink" target="_blank" rel="noopener" aria-disabled="true" class="btn-secondary hidden">Open preview image</a>
           </div>
         </div>
 
-        <div>
-          <h3 class="mb-2 text-sm font-semibold text-gray-700">Validation checklist</h3>
-          <div data-onboarding-wizard-target="validationLinks" class="space-y-2"></div>
+        <div class="panel-soft p-4">
+          <h3 class="text-sm font-bold text-[var(--osig-ink)]">Validation links</h3>
+          <div data-onboarding-wizard-target="validationLinks" class="mt-3 flex flex-wrap gap-3"></div>
         </div>
 
-        <p data-onboarding-wizard-target="errorMessage" class="text-sm text-red-600"></p>
+        <p data-onboarding-wizard-target="errorMessage" class="text-sm font-semibold text-[var(--osig-danger)]"></p>
 
-        <div class="flex justify-between">
-          <button type="button" data-action="onboarding-wizard#goPrevious" class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">Back</button>
-          <button type="button" data-action="onboarding-wizard#reset" class="px-4 py-2 text-white bg-red-600 rounded-md hover:bg-red-700">Start over</button>
+        <div class="flex justify-between gap-3">
+          <button type="button" data-action="onboarding-wizard#goPrevious" class="btn-secondary">Back</button>
+          <button type="button" data-action="onboarding-wizard#reset" class="btn-danger">Start over</button>
         </div>
       </section>
     </form>
   </div>
-</div>
+</section>
 {% endblock content %}

--- a/frontend/templates/pages/pricing.html
+++ b/frontend/templates/pages/pricing.html
@@ -26,132 +26,129 @@
 {% endblock meta %}
 
 {% block content %}
-<div class="py-24 bg-white sm:py-32">
-  <div class="px-6 mx-auto max-w-7xl lg:px-8">
-    <div class="mx-auto max-w-4xl sm:text-center">
-      <p class="text-base font-semibold leading-7 text-indigo-600">Pricing</p>
-      <h1 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Free to use and <a href="https://github.com/rasulkireev/osig" class="text-blue-600 underline hover:text-blue-700">self-host</a></h1>
+<section class="site-container py-12 lg:py-16">
+  <div class="grid gap-8 lg:grid-cols-[0.85fr_1.15fr] lg:items-end">
+    <div>
+      <p class="page-kicker">Pricing</p>
+      <h1 class="page-title mt-4">Free to use. Upgrade when the watermark matters.</h1>
     </div>
-    <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600 sm:text-center">OSIG is completely free to use for anyone and can be <a href="https://github.com/rasulkireev/osig" class="text-blue-600 underline hover:text-blue-700">self-hosted</a>. For additional features and support, check out our paid plans below.</p>
-    <div class="flow-root mt-20">
-      <div class="grid isolate grid-cols-1 gap-y-16 -mt-16 max-w-sm divide-y divide-gray-100 sm:mx-auto lg:-mx-8 lg:mt-0 lg:max-w-none lg:grid-cols-3 lg:divide-x lg:divide-y-0 xl:-mx-4">
-        <div class="pt-16 lg:px-8 lg:pt-0 xl:px-14">
-          <h3 id="tier-basic" class="text-base font-semibold leading-7 text-gray-900">Monthly</h3>
-          <p class="flex gap-x-1 items-baseline mt-6">
-            <span class="text-5xl font-bold tracking-tight text-gray-900">$10</span>
-            <span class="text-sm font-semibold leading-6 text-gray-600">/month</span>
-          </p>
-
-          {% if user.is_authenticated %}
-            {% if has_pro_subscription %}
-              <a href="#" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">You are a pro!</a>
-            {% else %}
-              <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='monthly' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-            {% endif %}
-          {% else %}
-            <a href="{% url 'account_signup' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-          {% endif %}
-
-          <ul role="list" class="mt-6 space-y-3 text-sm leading-6 text-gray-600">
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              Remove the watermark
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              More styling options
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              48-hour support response time
-            </li>
-          </ul>
-        </div>
-        <div class="pt-16 lg:px-8 lg:pt-0 xl:px-14">
-          <h3 id="tier-essential" class="text-base font-semibold leading-7 text-gray-900">Annual</h3>
-          <p class="flex gap-x-1 items-baseline mt-6">
-            <span class="text-5xl font-bold tracking-tight text-gray-900">$100</span>
-            <span class="text-sm font-semibold leading-6 text-gray-600">/year</span>
-          </p>
-
-          {% if user.is_authenticated %}
-            {% if has_pro_subscription %}
-              <a href="#" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">You are a pro!</a>
-            {% else %}
-              <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='yearly' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-            {% endif %}
-          {% else %}
-            <a href="{% url 'account_signup' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-          {% endif %}
-
-          <ul role="list" class="mt-6 space-y-3 text-sm leading-6 text-gray-600">
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              Remove the watermark
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              More styling options
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              48-hour support response time
-            </li>
-          </ul>
-        </div>
-        <div class="pt-16 lg:px-8 lg:pt-0 xl:px-14">
-          <h3 id="tier-growth" class="text-base font-semibold leading-7 text-gray-900">One-time</h3>
-          <p class="flex gap-x-1 items-baseline mt-6">
-            <span class="text-5xl font-bold tracking-tight text-gray-900">$500</span>
-          </p>
-
-          {% if user.is_authenticated %}
-            {% if has_pro_subscription %}
-              <a href="#" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">You are a pro!</a>
-            {% else %}
-              <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='one-time' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-            {% endif %}
-          {% else %}
-            <a href="{% url 'account_signup' %}" aria-describedby="tier-basic" class="block px-3 py-2 mt-10 text-sm font-semibold leading-6 text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Buy plan</a>
-          {% endif %}
-
-          <ul role="list" class="mt-6 space-y-3 text-sm leading-6 text-gray-600">
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              Remove the watermark
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              More styling options
-            </li>
-            <li class="flex gap-x-3">
-              <svg class="flex-none w-5 h-6 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
-              </svg>
-              48-hour support response time
-            </li>
-          </ul>
-        </div>
-      </div>
+    <div class="panel-soft p-5">
+      <p class="lede">
+        OSIG can be used for free and <a href="https://github.com/rasulkireev/osig" class="link">self-hosted from GitHub</a>. Paid plans remove the watermark and support hosted usage.
+      </p>
     </div>
   </div>
-</div>
+
+  <div class="mt-10 grid gap-5 lg:grid-cols-4">
+    <section class="panel p-6 lg:col-span-1">
+      <h2 class="text-lg font-bold">Free</h2>
+      <p class="mt-4 flex items-baseline gap-1">
+        <span class="text-4xl font-extrabold tracking-tight">$0</span>
+      </p>
+      <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+        Good for trying templates, testing social previews, and self-hosting the project.
+      </p>
+      <a href="{% url 'home' %}#generator" class="btn-secondary mt-8 w-full">Use generator</a>
+      <ul class="mt-6 space-y-3 text-sm text-[var(--osig-muted)]">
+        <li>Hosted image generator</li>
+        <li>Open source codebase</li>
+        <li>Watermark included</li>
+      </ul>
+    </section>
+
+    <section class="panel p-6 lg:col-span-1">
+      <h2 id="tier-basic" class="text-lg font-bold">Monthly</h2>
+      <p class="mt-4 flex items-baseline gap-1">
+        <span class="text-4xl font-extrabold tracking-tight">$10</span>
+        <span class="text-sm font-semibold text-[var(--osig-muted)]">/month</span>
+      </p>
+      <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+        Use when you want watermark-free previews without a long commitment.
+      </p>
+      {% if user.is_authenticated %}
+        {% if has_pro_subscription %}
+          <span aria-describedby="tier-basic" class="btn-secondary mt-8 w-full">Current access</span>
+        {% else %}
+          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='monthly' %}" aria-describedby="tier-basic" class="btn-primary mt-8 w-full">Start monthly plan</a>
+        {% endif %}
+      {% else %}
+        <a href="{% url 'account_signup' %}" aria-describedby="tier-basic" class="btn-primary mt-8 w-full">Create account</a>
+      {% endif %}
+      <ul class="mt-6 space-y-3 text-sm text-[var(--osig-muted)]">
+        <li>Remove hosted watermark</li>
+        <li>More styling options</li>
+        <li>48-hour support response time</li>
+      </ul>
+    </section>
+
+    <section class="panel border-[var(--osig-accent)] p-6 lg:col-span-1">
+      <div class="flex items-center justify-between gap-3">
+        <h2 id="tier-essential" class="text-lg font-bold">Annual</h2>
+        <span class="rounded-full bg-[var(--osig-accent-soft)] px-3 py-1 text-xs font-bold text-[var(--osig-accent-strong)]">Best value</span>
+      </div>
+      <p class="mt-4 flex items-baseline gap-1">
+        <span class="text-4xl font-extrabold tracking-tight">$100</span>
+        <span class="text-sm font-semibold text-[var(--osig-muted)]">/year</span>
+      </p>
+      <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+        Use when OSIG is part of your regular publishing workflow.
+      </p>
+      {% if user.is_authenticated %}
+        {% if has_pro_subscription %}
+          <span aria-describedby="tier-essential" class="btn-secondary mt-8 w-full">Current access</span>
+        {% else %}
+          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='yearly' %}" aria-describedby="tier-essential" class="btn-primary mt-8 w-full">Start annual plan</a>
+        {% endif %}
+      {% else %}
+        <a href="{% url 'account_signup' %}" aria-describedby="tier-essential" class="btn-primary mt-8 w-full">Create account</a>
+      {% endif %}
+      <ul class="mt-6 space-y-3 text-sm text-[var(--osig-muted)]">
+        <li>Remove hosted watermark</li>
+        <li>More styling options</li>
+        <li>48-hour support response time</li>
+      </ul>
+    </section>
+
+    <section class="panel p-6 lg:col-span-1">
+      <h2 id="tier-growth" class="text-lg font-bold">One-time</h2>
+      <p class="mt-4 flex items-baseline gap-1">
+        <span class="text-4xl font-extrabold tracking-tight">$500</span>
+      </p>
+      <p class="mt-4 text-sm leading-6 text-[var(--osig-muted)]">
+        Use when you prefer a one-time hosted upgrade instead of a subscription.
+      </p>
+      {% if user.is_authenticated %}
+        {% if has_pro_subscription %}
+          <span aria-describedby="tier-growth" class="btn-secondary mt-8 w-full">Current access</span>
+        {% else %}
+          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='one-time' %}" aria-describedby="tier-growth" class="btn-primary mt-8 w-full">Buy lifetime access</a>
+        {% endif %}
+      {% else %}
+        <a href="{% url 'account_signup' %}" aria-describedby="tier-growth" class="btn-primary mt-8 w-full">Create account</a>
+      {% endif %}
+      <ul class="mt-6 space-y-3 text-sm text-[var(--osig-muted)]">
+        <li>Remove hosted watermark</li>
+        <li>More styling options</li>
+        <li>48-hour support response time</li>
+      </ul>
+    </section>
+  </div>
+
+  <section class="mt-10 grid gap-5 lg:grid-cols-3">
+    <div class="panel-soft p-5">
+      <h2 class="text-base font-bold">Self-hosting</h2>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Run OSIG from the open source repo when you want full control over deployment and output.</p>
+    </div>
+    <div class="panel-soft p-5">
+      <h2 class="text-base font-bold">Hosted convenience</h2>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Use hosted URLs when you want previews available without operating the service yourself.</p>
+    </div>
+    <div class="panel-soft p-5">
+      <h2 class="text-base font-bold">Publishing fit</h2>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Upgrade only when watermark-free social images are part of how you ship pages.</p>
+    </div>
+  </section>
+</section>
 {% endblock content %}
 
 {% block schema %}

--- a/frontend/templates/pages/user-settings.html
+++ b/frontend/templates/pages/user-settings.html
@@ -11,114 +11,83 @@
 {% endblock schema %}
 
 {% block content %}
-  <div class="container px-4 py-8 mx-auto max-w-3xl bg-white lg:min-w-0 md:pt-10 lg:flex-1">
-    {% include "components/confirm-email.html" with email_verified=email_verified %}
-    <div class="p-4 border-t border-b border-gray-200 sm:p-6 lg:p-8 xl:border-t-0">
-      <div class="flex justify-between items-center">
-        <h1 class="flex-1 pt-2 text-xl font-medium">Settings</h1>
-      </div>
+  <section class="site-container-narrow py-12 lg:py-16">
+    <div>
+      <p class="page-kicker">Account</p>
+      <h1 class="section-title mt-3">Settings</h1>
+      <p class="lede mt-4">Manage your hosted access, profile details, and API token.</p>
     </div>
+
+    {% include "components/confirm-email.html" with email_verified=email_verified %}
 
     {% if not has_pro_subscription %}
-    <div class="p-6 mt-6 mb-8 bg-gray-50 rounded-lg">
-      <h3 class="mb-4 text-lg font-medium leading-6 text-gray-900">Upgrade Your Account</h3>
-      <p class="mb-4 text-sm text-gray-600">Choose a plan that suits your needs:</p>
-      <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <div class="rounded-md shadow">
-          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='monthly' %}"
-             class="flex justify-center items-center px-4 py-3 h-full text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent transition duration-150 ease-in-out md:text-base hover:bg-blue-700">
-            Monthly - $10/m
-          </a>
+    <section class="panel mt-8 p-5">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-lg font-bold">Upgrade hosted images</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Remove the watermark and keep using the hosted generator.</p>
         </div>
-        <div class="rounded-md shadow">
-          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='yearly' %}"
-             class="flex justify-center items-center px-4 py-3 h-full text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent transition duration-150 ease-in-out md:text-base hover:bg-blue-700">
-            Yearly - $100/y
-          </a>
-        </div>
-        <div class="rounded-md shadow">
-          <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='one-time' %}"
-             class="flex justify-center items-center px-4 py-3 h-full text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent transition duration-150 ease-in-out md:text-base hover:bg-blue-700">
-            One-time - $500
-          </a>
-        </div>
+        <a href="{% url 'pricing' %}" class="btn-secondary">Compare plans</a>
       </div>
-    </div>
+      <div class="mt-5 grid gap-3 md:grid-cols-3">
+        <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='monthly' %}" class="btn-primary">Start monthly</a>
+        <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='yearly' %}" class="btn-primary">Start annual</a>
+        <a href="{% url 'user_upgrade_checkout_session' pk=user.id plan='one-time' %}" class="btn-primary">Buy lifetime</a>
+      </div>
+    </section>
     {% else %}
-    <div class="p-6 mt-6 mb-8 bg-gray-50 rounded-lg">
-      <h3 class="mb-4 text-lg font-medium leading-6 text-gray-900">Manage Your Subscription</h3>
-      <div class="rounded-md shadow">
-        <a
-          href="{% url 'create_customer_portal_session' %}"
-          class="flex justify-center items-center px-5 py-3 text-base font-medium text-white bg-blue-600 rounded-md border border-transparent hover:bg-blue-700">
-          Update Subscription
-        </a>
+    <section class="panel mt-8 p-5">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-lg font-bold">Subscription active</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Manage billing, payment details, and renewal settings in the customer portal.</p>
+        </div>
+        <a href="{% url 'create_customer_portal_session' %}" class="btn-primary">Open billing portal</a>
       </div>
-    </div>
+    </section>
     {% endif %}
 
-    <div class="px-6 py-4 bg-gray-50 rounded-md">
-      <div class="flex flex-col">
-        <h3 class="mb-6 text-lg font-medium leading-6 text-gray-900">Personal Information</h3>
-        <div class="mt-5 md:mt-0">
-          <form action="" method="post">
-            {% csrf_token %}
-            <div class="overflow-hidden sm:rounded-md">
-              <div class="px-2 py-5">
-                <div class="grid grid-cols-6 gap-6">
-                  {{ form.non_field_errors }}
-                  <div class="col-span-6 sm:col-span-3">
-                    {{ form.first_name.errors | safe }}
-                    <label for="{{ form.first_name.id_for_label }}" class="block text-sm font-medium text-gray-700">First name</label>
-                    {% render_field form.first_name id="first-name" name="first-name" type="text" autocomplete="given-name" class="block mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm" %}
-                  </div>
-
-                  <div class="col-span-6 sm:col-span-3">
-                    {{ form.last_name.errors | safe }}
-                    <label for="{{ form.last_name.id_for_label }}" class="block text-sm font-medium text-gray-700">Last name</label>
-                    {% render_field form.last_name id="last-name" name="last-name" type="text" autocomplete="family-name" class="block mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm" %}
-                  </div>
-
-                  <div class="col-span-6">
-                    {{ form.email.errors | safe }}
-                    <label for="{{ form.email.id_for_label }}" class="block text-sm font-medium text-gray-700">Email address</label>
-                    {% render_field form.email id="email-address" name="email-address" type="email" autocomplete="email" class="block mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm" %}
-                  </div>
-                </div>
-              </div>
-              <div class="mt-6 text-right">
-                <button type="submit" class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">Save Changes</button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
-
-    <div class="block" aria-hidden="true">
-      <div class="py-5">
-        <div class="border-t border-gray-200"></div>
-      </div>
-    </div>
-
-    <!-- New App Settings Section -->
-    <div class="px-6 py-4 bg-gray-50 rounded-md">
-      <div class="flex flex-col">
-        <h3 class="mb-6 text-lg font-medium leading-6 text-gray-900">App Settings</h3>
-        <div class="p-4">
-          <label for="user-token" class="block mb-2 text-sm font-medium text-gray-700">User Token</label>
-          <div class="flex">
-            <input type="text" id="user-token" value="{{ object.key }}" readonly class="flex-grow px-3 py-2 mr-2 text-sm text-gray-700 bg-white rounded-md border border-gray-300 shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-            <button onclick="copyToken()" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md border border-transparent shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
-              Copy
-            </button>
+    <section class="panel mt-6 p-5">
+      <h2 class="text-lg font-bold">Personal information</h2>
+      <form action="" method="post" class="mt-5">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div>
+            {{ form.first_name.errors | safe }}
+            <label for="{{ form.first_name.id_for_label }}" class="field-label">First name</label>
+            {% render_field form.first_name id="first-name" name="first-name" type="text" autocomplete="given-name" class="field" %}
           </div>
-          <p class="mt-2 text-sm text-gray-500">This is your unique user token that you can insert into image urls for authentication.</p>
-        </div>
-      </div>
-    </div>
 
-  </div>
+          <div>
+            {{ form.last_name.errors | safe }}
+            <label for="{{ form.last_name.id_for_label }}" class="field-label">Last name</label>
+            {% render_field form.last_name id="last-name" name="last-name" type="text" autocomplete="family-name" class="field" %}
+          </div>
+
+          <div class="sm:col-span-2">
+            {{ form.email.errors | safe }}
+            <label for="{{ form.email.id_for_label }}" class="field-label">Email address</label>
+            {% render_field form.email id="email-address" name="email-address" type="email" autocomplete="email" class="field" %}
+          </div>
+        </div>
+        <div class="mt-6 flex justify-end">
+          <button type="submit" class="btn-primary">Save changes</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel mt-6 p-5">
+      <h2 class="text-lg font-bold">API token</h2>
+      <p class="mt-2 text-sm leading-6 text-[var(--osig-muted)]">Use this token as the <span class="font-mono">key</span> parameter for authenticated image URLs.</p>
+      <div class="mt-5 flex flex-col gap-3 sm:flex-row">
+        <input type="text" id="user-token" value="{{ object.key }}" readonly class="field font-mono text-sm">
+        <button onclick="copyToken()" class="btn-secondary sm:w-32" type="button">
+          Copy token
+        </button>
+      </div>
+    </section>
+  </section>
 
   <script>
     function copyToken() {

--- a/frontend/templates/pages/uses.html
+++ b/frontend/templates/pages/uses.html
@@ -24,33 +24,54 @@
 {% endblock meta %}
 
 {% block content %}
-    <div class="container px-4 py-8 mx-auto prose">
-        <h1>Tech I Use</h1>
-        <p>
-          I run
-          <a href="https://www.rasulkireev.com/projects">multiple projects</a>
-          at the same time and using reliable and simple tech is the key to running everything smoothly. Here's what I use:
-        </p>
-        <ul>
-            <li><strong><a href="https://osig.app/" target="_blank" rel="noopener noreferrer">OSIG</a>:</strong> For pretty OG images.</li>
-            <li><strong><a href="https://statushen.com/" target="_blank" rel="noopener noreferrer">Statushen</a>:</strong> For a Status Page.</li>
-            <li><strong><a href="https://sentry.io/" target="_blank" rel="noopener noreferrer">Sentry</a>:</strong> For error tracking and performance monitoring, ensuring a smooth user experience.</li>
-            <li><strong><a href="https://hetzner.cloud/?ref=Ju1ttKSG0Fn7" target="_blank" rel="noopener noreferrer">Hetzner</a>:</strong> Our cloud infrastructure provider, hosting our servers and services.</li>
-            <li><strong><a href="https://buttondown.email/refer/rasulkireev" target="_blank" rel="noopener noreferrer">Buttondown</a>:</strong> for the newsletter.</li>
-            <li><strong><a href="https://www.djangoproject.com/" target="_blank" rel="noopener noreferrer">Django</a>:</strong> Our primary web framework, providing a robust foundation for our backend.</li>
-            <li><strong><a href="https://django-q2.readthedocs.io/" target="_blank" rel="noopener noreferrer">Django-Q2</a>:</strong> A task queue and scheduler for Django, helping us manage background tasks efficiently.</li>
-            <li><strong><a href="https://caprover.com/" target="_blank" rel="noopener noreferrer">CapRover</a>:</strong> Our deployment and server management tool, simplifying our DevOps processes.</li>
-            <li><strong><a href="https://github.com/" target="_blank" rel="noopener noreferrer">GitHub</a>:</strong> For version control and collaborative development of our codebase.</li>
-            <li><strong><a href="https://redis.io/" target="_blank" rel="noopener noreferrer">Redis</a>:</strong> An in-memory data structure store, used as a database, cache, and message broker.</li>
-            <li><strong><a href="https://www.postgresql.org/" target="_blank" rel="noopener noreferrer">PostgreSQL</a>:</strong> Our primary relational database management system.</li>
-            <li><strong><a href="https://www.anthropic.com/" target="_blank" rel="noopener noreferrer">Anthropic</a>:</strong> Leveraging AI capabilities to enhance our services.</li>
-            <li><strong><a href="https://replicate.com/" target="_blank" rel="noopener noreferrer">Replicate</a>:</strong> For AI model deployment and management.</li>
-            <li><strong><a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer">OpenTelemetry</a>:</strong> Providing observability into our application's performance and behavior.</li>
-            <li><strong><a href="https://stimulus.hotwired.dev/" target="_blank" rel="noopener noreferrer">StimulusJS</a>:</strong> A modest JavaScript framework for the "sprinkles of interactivity" in our frontend.</li>
-            <li><strong><a href="https://whitenoise.evans.io/" target="_blank" rel="noopener noreferrer">WhiteNoise</a>:</strong> For efficient serving of static files.</li>
-        </ul>
-        <p>If you have any questions about our technology choices or are interested in learning more, feel free to contact us at <a href="mailto:contact@osig.app">contact@osig.app</a>.</p>
-    </div>
+    <section class="site-container py-12 lg:py-16">
+        <div class="max-w-3xl">
+            <p class="page-kicker">Uses</p>
+            <h1 class="page-title mt-4">The stack behind OSIG.</h1>
+            <p class="lede mt-6">
+              OSIG is built with simple infrastructure and tools that are easy to operate across multiple small projects.
+            </p>
+        </div>
+
+        <div class="mt-10 grid gap-5 lg:grid-cols-3">
+            <section class="panel p-5">
+                <h2 class="text-lg font-bold">Product</h2>
+                <ul class="mt-4 space-y-3 text-sm leading-6 text-[var(--osig-muted)]">
+                    <li><a href="https://osig.app/" target="_blank" rel="noopener noreferrer" class="link">OSIG</a>: generated Open Graph images.</li>
+                    <li><a href="https://statushen.com/" target="_blank" rel="noopener noreferrer" class="link">Statushen</a>: public status page.</li>
+                    <li><a href="https://buttondown.email/refer/rasulkireev" target="_blank" rel="noopener noreferrer" class="link">Buttondown</a>: newsletter delivery.</li>
+                </ul>
+            </section>
+
+            <section class="panel p-5">
+                <h2 class="text-lg font-bold">Application</h2>
+                <ul class="mt-4 space-y-3 text-sm leading-6 text-[var(--osig-muted)]">
+                    <li><a href="https://www.djangoproject.com/" target="_blank" rel="noopener noreferrer" class="link">Django</a>: primary web framework.</li>
+                    <li><a href="https://django-q2.readthedocs.io/" target="_blank" rel="noopener noreferrer" class="link">Django-Q2</a>: background tasks and scheduled work.</li>
+                    <li><a href="https://stimulus.hotwired.dev/" target="_blank" rel="noopener noreferrer" class="link">StimulusJS</a>: focused frontend interactivity.</li>
+                    <li><a href="https://replicate.com/" target="_blank" rel="noopener noreferrer" class="link">Replicate</a>: AI model deployment.</li>
+                </ul>
+            </section>
+
+            <section class="panel p-5">
+                <h2 class="text-lg font-bold">Operations</h2>
+                <ul class="mt-4 space-y-3 text-sm leading-6 text-[var(--osig-muted)]">
+                    <li><a href="https://hetzner.cloud/?ref=Ju1ttKSG0Fn7" target="_blank" rel="noopener noreferrer" class="link">Hetzner</a>: cloud infrastructure.</li>
+                    <li><a href="https://caprover.com/" target="_blank" rel="noopener noreferrer" class="link">CapRover</a>: deployment management.</li>
+                    <li><a href="https://www.postgresql.org/" target="_blank" rel="noopener noreferrer" class="link">PostgreSQL</a>: relational database.</li>
+                    <li><a href="https://redis.io/" target="_blank" rel="noopener noreferrer" class="link">Redis</a>: cache and message broker.</li>
+                    <li><a href="https://sentry.io/" target="_blank" rel="noopener noreferrer" class="link">Sentry</a>: error tracking.</li>
+                    <li><a href="https://opentelemetry.io/" target="_blank" rel="noopener noreferrer" class="link">OpenTelemetry</a>: observability.</li>
+                </ul>
+            </section>
+        </div>
+
+        <div class="panel-soft mt-8 p-5">
+            <p class="text-sm leading-6 text-[var(--osig-muted)]">
+                Questions about the stack? Email <a href="mailto:contact@osig.app" class="link">contact@osig.app</a>.
+            </p>
+        </div>
+    </section>
 {% endblock content %}
 
 {% block schema %}


### PR DESCRIPTION
## Summary
- Redesign the shared shell and public OSIG surfaces around the working generator/docs flow.
- Add a reusable frontend design system, revised nav/footer, clearer generator controls, and updated account/blog/pricing/settings pages.
- Add PRODUCT.md, DESIGN.md, and impeccable live config to document the product/design direction.
- Preserve the new MCP documentation from main inside the redesigned docs page.

## Verification
- npm run build
- uv run python manage.py check
- uv run pytest

## Notes
- Local Django checks were run with SQLite and dummy local service credentials.
- Webpack still reports the existing Browserslist database notice and vendors/images/sample.jpg size warning.