### PR TITLE
[OSIG] Simplify Public MCP Setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,8 @@ ENVIRONMENT=dev
 
 # Container role for the shared deployment image.
 # Required in production containers. Docker Compose overrides this per service.
-# Use "server" for the web app and "worker" for the background workers app.
+# Use "server" for the web app, "worker" for background workers, and "mcp"
+# for the standalone FastMCP HTTP server.
 APP_PROCESS_TYPE=
 
 # Optional image override for docker-compose-prod.yml.
@@ -41,6 +42,11 @@ REDIS_PASSWORD=osig
 REDIS_PORT=6379
 REDIS_DB=0
 REDIS_URL=redis://:osig@redis:6379/0
+
+# Optional FastMCP HTTP sidecar settings.
+MCP_HOST=127.0.0.1
+MCP_PORT=8765
+MCP_PATH=/mcp
 
 # If you want to enable Social Auth via GitHub.
 # Homepage URL: http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -1,379 +1,81 @@
-# OG Image Generator Documentation
+# OSIG
+
+OSIG renders Open Graph and Twitter/X preview images from URL parameters.
+
+It has two separate usage paths:
+
+- Human website usage: see [docs/human-usage.md](docs/human-usage.md)
+- AI agent usage through MCP: see [docs/agent-mcp.md](docs/agent-mcp.md)
+
+The public image endpoint remains:
+
+```text
+https://osig.app/g
+```
+
+Existing unsigned `/g` image URLs keep working for backwards compatibility.
 
 ## Development
 
-Python dependencies are managed with `uv`. For the Dockerized local stack, run:
+Python dependencies are managed with `uv`.
 
-```
+Run the local Docker stack:
+
+```bash
 make serve
 ```
 
-The local backend and worker services use `Dockerfile-python`, and production deploys build one shared image from `deployment/Dockerfile`. At runtime, `APP_PROCESS_TYPE=server` starts Gunicorn and `APP_PROCESS_TYPE=worker` starts Django Q workers. For CapRover, set `APP_PROCESS_TYPE=server` on the `osig` app and `APP_PROCESS_TYPE=worker` on the `osig-workers` app.
+For native local commands outside Docker, create a local env file first:
 
-For AI-agent iteration on generated images, OSIG exposes a hosted FastMCP server at `/mcp/` from the web container. Hosted requests authenticate with an OSIG profile key via `X-API-Key` or `Authorization: Bearer <key>`.
-
-For local stdio clients, run:
-
-```
-uv run python mcp_server.py
+```bash
+cp .env.example .env
 ```
 
-See [docs/agent-mcp.md](docs/agent-mcp.md) for the tool contract and transport notes.
+If you are not running Docker Postgres locally, set `DATABASE_URL=sqlite:///db.sqlite3` in `.env`.
 
-## How to use?
+Run tests:
 
-The OG Image Generator allows you to create custom Open Graph images for your website. You can specify various parameters to customize the image according to your needs.
-
-### URL
-
-The url for all images will be the same:
-
-`https://osig.app/g/`
-
-### Parameters
-
-Parameters will vary depending on the style. All of them are optional, but if you don't pass anything it will look like sh\*t.
-
-![OG Image Generator Parameters](https://osig.app/static/vendors/images/no-params-example.0b515a8143fb.png)
-
-Below is a list of all parameters we currently support:
-
-*   **key**: Your API key. Can be found in your [settings](/settings) page, if you are registered.
-*   **style**: Image style (default: "base")
-    *   \- [base](#base)
-    *   \- [logo](#logo)
-    *   \- [job_classic](#job-board-template-pack-v1)
-    *   \- [job_logo](#job-board-template-pack-v1)
-    *   \- [job_clean](#job-board-template-pack-v1)
-*   **site**: This dictates the size of the image (default: "x")
-    *   \- x (1600 by 900)
-    *   \- meta (1200 by 630)
-*   **font**: Font to use for text (more will be added)
-    *   \- [helvetica](#Helvetica)
-    *   \- [markerfelt](#Markerfelt)
-    *   \- [papyrus](#Papyrus)
-*   **title**: Main title text
-*   **subtitle**: Subtitle text
-*   **eyebrow**: Eyebrow text
-*   **image\_url**: URL of the background image
-*   **image\_or\_logo**: Alias for `image_url`, recommended for job-board templates where the asset can be either a hero image or company logo.
-*   **format**: Output format (`png` or `jpeg`, default: `png`)
-*   **quality**: Compression quality (`1-100`).
-    * For `jpeg`: defaults to `85` if omitted.
-    * For `png`: optional, controls compression level when provided.
-*   **max_kb**: Optional target size in KB (best-effort, currently tuned for `jpeg`).
-*   **v**: Optional cache-busting version token. Change this when you want social previews to refresh.
-*   **exp** + **sig**: Optional expiry/signature pair for tamper-proof signed URLs (generated via `POST /api/sign`).
-
-### Usage
-
-The url for all images will be the same:
-
-```
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:image" content="{ generated_image_url }"/>
+```bash
+make test
 ```
 
-### Examples
+## Runtime Processes
 
-#### Base Style
+Production builds one image from `deployment/Dockerfile`. The process is selected with `APP_PROCESS_TYPE`:
 
-This is useful for general pages like Articles, Tutorial, News pages. Pro tip, you can generate the background image using AI. Those work super well.
+- `server`: Django ASGI app. Serves the website, `/g`, API routes, and the mounted FastMCP app at `/mcp`.
+- `worker`: Django Q workers.
+- `mcp`: optional standalone FastMCP Streamable HTTP sidecar from `mcp_http_server.py`.
 
-Here is what gets generated for my site's articles:
+The `server` process uses:
 
-![Base OG Image Example](https://osig.app/static/vendors/images/base-example.73fce7ac82c5.png)
-
-This is the that I use to generate the image:
-
-```
-https://osig.app/g?
-  site=x
-  &style=base
-  &font=helvetica
-  &title=10 Years of Great Books
-  &subtitle=I'm starting a 10 Year Reading Plan proposed in the 1st Volume (The Great Conversation) of the "Great Books of the Western World" series.
-  &eyebrow=Article
-  &image_url=https://www.rasulkireev.com/_astro/a_smiling_boy_from_Pixars_Coco.DrP3G0Ol.png
+```bash
+gunicorn osig.asgi:application --worker-class uvicorn_worker.UvicornWorker
 ```
 
-#### Logo Style
+The standalone MCP process uses:
 
-Logo style is super useful if you are trying to highlight a company or a project, advertize job postings or anything like. Super minimalistic.
-
-Here is how I use it for one of my job boards:
-
-![Logo OG Image Example](https://osig.app/static/vendors/images/logo-example.818309c1b90d.png)
-
-This is the that I use to generate the image:
-
-```
-https://osig.app/g?
-  site=x
-  &style=logo
-  &font=markerfelt
-  &title=Narrative
-  &subtitle=Founding Senior Software Engineer
-  &image_url=http://res.cloudinary.com/built-with-django/image/upload/v1728024021/user-profile-image-prod/hhxfplsthiaytuttoamc.jpg
+```bash
+uv run python mcp_http_server.py
 ```
 
-#### Job-board template pack v1
+By default, local MCP HTTP runs at:
 
-Wave 1 ships three production-ready job-board styles:
-
-- `job_classic`: full-bleed background + high-contrast copy
-- `job_logo`: role-focused copy with circular logo slot
-- `job_clean`: minimal white layout with accent bar and logo slot
-
-All three templates support the same core fields:
-
-- `title`
-- `subtitle`
-- `eyebrow`
-- `image_or_logo` (alias for `image_url`)
-
-Copy is safely truncated to keep layouts stable for long job titles/descriptions.
-
-Example:
-
-```
-https://osig.app/g?
-  site=x
-  &style=job_logo
-  &font=helvetica
-  &title=Senior Django Engineer
-  &subtitle=Build reliable product features and own the roadmap.
-  &eyebrow=Remote · Full-time
-  &image_or_logo=https://example.com/company-logo.png
+```text
+http://127.0.0.1:8765/mcp
 ```
 
-### Fonts
+Set `MCP_HOST`, `MCP_PORT`, or `MCP_PATH` to override that.
 
-*   Helvetica ![Helvetica Font Example](https://osig.app/static/vendors/images/helvetica-example.9d748f0e4cd3.png)
-*   Markerfelt ![Markerfelt Font Example](https://osig.app/static/vendors/images/markerfelt-example.f0edc54d9ba4.png)
-*   Papyrus ![Papyrus Font Example](https://osig.app/static/vendors/images/papyrus-example.03867e8bc712.png)
+## MCP Trial Auth
 
-### Precautions
+MCP is intentionally unauthenticated for now so it is easy to try from Codex and other agent clients.
 
-Once you insert this link on your site, make sure to test it before sharing links online. I like to use [this Twitter Card Validator](https://threadcreator.com/tools/twitter-card-validator)
-
-### Notes
-
-*   Subtitle text is truncated to 150 characters if longer.
-*   You can remove the watermark by subscribing to the [PRO version](/pricing).
-
-### Integrating into your Site
-
-As people use this, I will start adding more specific instructions on how to add these to your specific site that might use different technologies:
-
-*   Wordpress
-*   Django
-*   Astro
-*   Ruby on Rails
-*   Next.js
-*   etc.
-
-### API
-
-#### 1) Generate signed OG URLs
-
-Use this endpoint when you need tamper-proof URLs with expiration.
-
-`POST /api/sign`
-
-Request body example:
-
-```json
-{
-  "params": {
-    "style": "logo",
-    "site": "x",
-    "title": "Narrative",
-    "subtitle": "Founding Senior Software Engineer",
-    "image_url": "https://example.com/logo.png",
-    "format": "jpeg",
-    "quality": 80,
-    "v": "2026-02-26"
-  },
-  "expires_in_seconds": 3600
-}
-```
-
-Response shape:
-
-```json
-{
-  "signed_url": "https://osig.app/g?...&exp=...&sig=...",
-  "expires_at": "2026-02-26T12:34:56+00:00"
-}
-```
-
-Validation rules on `GET /g`:
-
-- Tampered signed params -> `403`
-- Expired signed links -> `403`
-- Unsigned links still work for backwards compatibility
-
-#### 2) Output controls
-
-`GET /g` now supports:
-
-- `format=png|jpeg`
-- `quality=1..100`
-- `max_kb=<int>` (best-effort size targeting for jpeg)
-
-Content type is set explicitly:
-
-- PNG -> `image/png`
-- JPEG -> `image/jpeg`
-
-#### 3) Cache/versioning workflow
-
-`GET /g` responses now include explicit cache headers.
-
-- Unsigned URLs: `Cache-Control: public, max-age=31536000, immutable`
-- Signed URLs: `Cache-Control: public, max-age=<seconds until exp>`
-
-Use `v` to force cache key rotation without changing title/subtitle payload:
-
-1. Keep your normal OG params.
-2. When image content changes, bump `v` (for example, `v=2026-03-01`).
-3. Re-embed/re-publish URLs with the new `v` value.
-4. If using signed URLs, regenerate via `POST /api/sign` so `sig` matches the new params.
-
-Social preview refresh checklist:
-
-- Bump `v`
-- Regenerate signed URL (if signed)
-- Re-deploy metadata with the new URL
-- Re-validate on social debuggers (X Card Validator / LinkedIn Post Inspector / Facebook Sharing Debugger)
-
-### 4) Onboarding wizard helper
-
-`GET /onboarding` now exposes a 5-step guided wizard that outputs:
-
-- signed OG image URL (reuses `POST /api/sign`)
-- copy-ready OG/Twitter meta tags
-- validation links (X/Twitter, Facebook, LinkedIn, Google rich results)
-
-Backend helper endpoint used by the wizard:
-
-`POST /api/onboarding/meta`
-
-Example:
-
-```json
-{
-  "page_url": "https://example.com/jobs/senior-engineer",
-  "style": "job_logo",
-  "site": "x",
-  "font": "helvetica",
-  "title": "Senior Engineer",
-  "subtitle": "Ship reliable backend systems",
-  "eyebrow": "Remote · Full-time",
-  "image_url": "https://example.com/logo.png",
-  "format": "jpeg",
-  "quality": 80,
-  "version": "v2026-02-26"
-}
-```
-
-Response:
-
-```json
-{
-  "signed_url": "https://osig.app/g?...&exp=...&sig=...",
-  "expires_at": "2026-02-26T12:34:56+00:00",
-  "meta_tags": "<meta ... />\n<meta ... />",
-  "validation_links": {
-    "Twitter/X Card Validator": "https://cards-dev.twitter.com/validator?url=..."
-  }
-}
-```
-
-### 5) Usage metering + quota enforcement
-
-Keyed requests to `/g` now include per-key usage metering with configurable limits.
-
-Config via environment:
-
-- `OSIG_DAILY_USAGE_LIMIT` (default: `1000`)
-- `OSIG_MONTHLY_USAGE_LIMIT` (default: `10000`)
-- `OSIG_USAGE_WARNING_PERCENT` (default: `0.8`)
-
-Behavior:
-
-- warns when usage crosses warning threshold (`X-OSIG-Quota-Warning`)
-- blocks at configured quota with `429`
-- exposes counters via:
-  - `X-OSIG-Daily-Usage`
-  - `X-OSIG-Monthly-Usage`
-
-Backward compatibility:
-
-- existing no-key `/g` flows remain unchanged
-
-Admin visibility:
-
-- usage records are visible in Django admin (`ProfileUsage`) and sorted by monthly usage for top-key visibility.
-
-### 6) Reliability + observability
-
-Render pipeline now ships with:
-
-- structured error taxonomy
-- transient retry policy
-- render-attempt metrics for fail-rate + p95 visibility
-
-Config:
-
-- `OSIG_RENDER_MAX_ATTEMPTS` (default `2`)
-- `OSIG_IMAGE_FETCH_TIMEOUT_SECONDS` (default `8`)
-
-Observability endpoint (superuser API key required):
-
-`GET /api/admin/render-metrics?api_key=<key>&hours=24`
-
-Example response:
-
-```json
-{
-  "window_hours": 24,
-  "total_attempts": 120,
-  "failed_attempts": 6,
-  "fail_rate_percent": 5.0,
-  "p95_render_ms": 284,
-  "error_counts": {
-    "transient_upstream_fetch": 4,
-    "validation_error": 2
-  }
-}
-```
-
-### 7) WordPress helper MVP
-
-`POST /api/integrations/wordpress` maps common WordPress fields to OSIG params and returns a ready signed URL.
-
-- maps `post_title`, `post_name`, `excerpt/description`, `featured_image_url/featured_image/logo`
-- supports `quality`, `max_kb`, `version` and cache-friendly URL parameters
-- applies image fallback chain:
-  1. `featured_image_url`
-  2. `featured_image`
-  3. `logo_url`
-  4. `fallback_image_url`
-  5. no image fallback
-
-Returns:
-
-- `signed_url`
-- `expires_at`
-- `mapped_fields`
-- `fallbacks`
-- `snippet` (PHP helper sample)
+Do not expose private/admin MCP tools while this remains public. User-scoped history tools still require an explicit OSIG profile key as a tool argument.
 
 ## Roadmap
 
-- Add instruction on how to self host.
-- Add more styles.
+- Add more image styles.
 - Add more fonts.
-- Add more sites.
+- Add more social/site presets.
+- Reintroduce MCP auth once the agent workflow is proven.

--- a/core/mcp.py
+++ b/core/mcp.py
@@ -20,7 +20,6 @@ from core.image_styles import generate_image_router
 from core.image_utils import get_image_dimensions
 from core.mcp_auth import authenticate_mcp_headers
 from core.models import Image as ImageModel, Profile
-from core.render_observability import build_render_metrics
 from core.signing import build_signed_params
 from osig.utils import get_osig_logger
 
@@ -200,12 +199,6 @@ def _params_for_request(params: ImageParams) -> ImageParams:
     return params.model_copy(update={"key": profile.key})
 
 
-def _require_http_superuser() -> None:
-    profile = _get_http_profile()
-    if profile is not None and not profile.user.is_superuser:
-        raise PermissionError("This MCP tool requires a superuser profile key.")
-
-
 def _summarize_image(image: ImageModel) -> dict[str, Any]:
     image_data = image.image_data or {}
 
@@ -242,7 +235,7 @@ def create_mcp() -> FastMCP:
         "OSIG Image Iteration MCP",
         instructions=(
             "Use these tools to inspect OSIG image capabilities, normalize render parameters, "
-            "generate local previews, create signed public image URLs, and inspect recent render health."
+            "generate previews, and create signed public image URLs."
         ),
         on_duplicate="error",
     )
@@ -282,7 +275,6 @@ def create_mcp() -> FastMCP:
                 "Call normalize_image_params to get canonical parameters and warnings.",
                 "Call render_image_preview while varying one or two fields at a time.",
                 "Call build_signed_image_url once the preview parameters are ready to publish.",
-                "Use get_recent_render_metrics if render failures or latency need investigation.",
             ],
         }
 
@@ -392,24 +384,6 @@ def create_mcp() -> FastMCP:
 
             images = [_summarize_image(image) for image in queryset[:limit]]
             return {"count": len(images), "images": images}
-        finally:
-            close_old_connections()
-
-    @mcp.tool(timeout=10)
-    def get_recent_render_metrics(window_hours: Annotated[int, Field(ge=1, le=24 * 30)] = 24) -> dict[str, Any]:
-        """Return aggregate render health metrics for the recent render-attempt window."""
-        close_old_connections()
-        try:
-            _require_http_superuser()
-            metrics = build_render_metrics(window_hours=window_hours)
-            return {
-                "window_hours": metrics.window_hours,
-                "total_attempts": metrics.total_attempts,
-                "failed_attempts": metrics.failed_attempts,
-                "fail_rate_percent": metrics.fail_rate_percent,
-                "p95_render_ms": metrics.p95_render_ms,
-                "error_counts": metrics.error_counts,
-            }
         finally:
             close_old_connections()
 

--- a/core/tests/test_mcp.py
+++ b/core/tests/test_mcp.py
@@ -9,8 +9,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from PIL import Image
 
-from core.models import Image as ImageModel, RenderAttempt
-from core.render_observability import RenderErrorType
+from core.models import Image as ImageModel
 
 
 def _run(coro):
@@ -48,8 +47,8 @@ def test_mcp_lists_image_iteration_tools():
         "render_image_preview",
         "build_signed_image_url",
         "list_recent_generated_images",
-        "get_recent_render_metrics",
     }.issubset(tool_names)
+    assert "get_recent_render_metrics" not in tool_names
 
 
 @pytest.mark.django_db(transaction=True)
@@ -296,37 +295,3 @@ def test_list_recent_generated_images_requires_and_scopes_by_key():
     assert result.data["count"] == 1
     assert result.data["images"][0]["params"]["title"] == "First image"
     assert missing_key_result.is_error is True
-
-
-@pytest.mark.django_db(transaction=True)
-def test_get_recent_render_metrics_reports_existing_attempts():
-    admin_user = User.objects.create_superuser(username="admin", email="admin@example.com", password="pass123")
-    profile = admin_user.profile
-
-    RenderAttempt.objects.create(profile=profile, key=profile.key, style="base", success=True, duration_ms=100)
-    RenderAttempt.objects.create(
-        profile=profile,
-        key=profile.key,
-        style="base",
-        success=False,
-        duration_ms=125,
-        error_type=RenderErrorType.TRANSIENT_UPSTREAM_FETCH,
-    )
-
-    result = _run(_call_tool("get_recent_render_metrics", {"window_hours": 24}))
-
-    assert result.data["total_attempts"] == 2
-    assert result.data["failed_attempts"] == 1
-    assert result.data["fail_rate_percent"] == 50.0
-    assert result.data["error_counts"][RenderErrorType.TRANSIENT_UPSTREAM_FETCH] == 1
-
-
-@pytest.mark.django_db(transaction=True)
-def test_get_recent_render_metrics_requires_superuser_for_hosted_auth(monkeypatch):
-    import core.mcp as core_mcp
-
-    user = User.objects.create_user(username="regular", email="regular@example.com", password="pass123")
-    monkeypatch.setattr(core_mcp, "_get_http_profile", lambda: user.profile)
-
-    with pytest.raises(ToolError):
-        _run(_call_tool("get_recent_render_metrics", {"window_hours": 24}))

--- a/core/tests/test_mcp_auth.py
+++ b/core/tests/test_mcp_auth.py
@@ -52,8 +52,11 @@ def test_asgi_application_mounts_hosted_mcp():
 
 
 def test_asgi_application_mounts_mcp_without_auth_middleware():
+    from starlette.routing import Mount
+
     from osig.asgi import application
 
-    mcp_route = next(route for route in application.routes if getattr(route, "path", "") == "/mcp")
+    mcp_mounts = [route for route in application.routes if isinstance(route, Mount) and route.path == "/mcp"]
 
-    assert not isinstance(mcp_route.app, McpAuthMiddleware)
+    assert len(mcp_mounts) == 1
+    assert not isinstance(mcp_mounts[0].app, McpAuthMiddleware)

--- a/core/tests/test_mcp_auth.py
+++ b/core/tests/test_mcp_auth.py
@@ -49,3 +49,11 @@ def test_asgi_application_mounts_hosted_mcp():
 
     assert "/mcp" in route_paths
     assert "" in route_paths
+
+
+def test_asgi_application_mounts_mcp_without_auth_middleware():
+    from osig.asgi import application
+
+    mcp_route = next(route for route in application.routes if getattr(route, "path", "") == "/mcp")
+
+    assert not isinstance(mcp_route.app, McpAuthMiddleware)

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -83,18 +83,17 @@ class TestSeoSurface:
             assert '<link rel="canonical" href="https://testserver' in body
             assert '<script type="application/ld+json">' in body
 
-    def test_how_to_page_documents_mcp_usage(self, client):
+    def test_how_to_page_keeps_human_usage_separate_from_mcp(self, client):
         response = client.get(reverse("how_to"))
 
         assert response.status_code == 200
         body = response.content.decode()
-        assert "Using the MCP" in body
-        assert "https://osig.app/mcp/" in body
-        assert "X-API-Key" in body
-        assert "get_image_generation_contract" in body
-        assert "normalize_image_params" in body
-        assert "render_image_preview" in body
-        assert "build_signed_image_url" in body
+        assert "Endpoint" in body
+        assert "https://osig.app/g" in body
+        assert "Using the MCP" not in body
+        assert "https://osig.app/mcp/" not in body
+        assert "X-API-Key" not in body
+        assert "get_image_generation_contract" not in body
 
     def test_site_url_uses_request_scheme_for_local_preview(self):
         request = RequestFactory().get("/how-to", HTTP_HOST="localhost:8000")

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -7,10 +7,11 @@ APP_PORT="${PORT:-80}"
 
 process_type="${APP_PROCESS_TYPE:-}"
 
-while getopts ":sw" option; do
+while getopts ":swm" option; do
     case "${option}" in
         s) process_type="server" ;;
         w) process_type="worker" ;;
+        m) process_type="mcp" ;;
         *)
             echo "Invalid option: -$OPTARG" >&2
             exit 1
@@ -21,7 +22,7 @@ shift $((OPTIND - 1))
 
 if [ -z "$process_type" ]; then
     if [ "${ENVIRONMENT:-}" = "prod" ]; then
-        echo "APP_PROCESS_TYPE must be set to 'server' or 'worker' when ENVIRONMENT=prod." >&2
+        echo "APP_PROCESS_TYPE must be set to 'server', 'worker', or 'mcp' when ENVIRONMENT=prod." >&2
         exit 1
     fi
 
@@ -70,8 +71,14 @@ case "$process_type" in
         echo "Starting OSIG workers..."
         exec uv run --no-sync python manage.py qcluster
         ;;
+    mcp)
+        echo "Starting OSIG MCP server..."
+        export MCP_HOST="${MCP_HOST:-0.0.0.0}"
+        export MCP_PORT="${MCP_PORT:-$APP_PORT}"
+        exec uv run --no-sync python mcp_http_server.py
+        ;;
     *)
-        echo "Invalid APP_PROCESS_TYPE: $process_type. Expected 'server' or 'worker'." >&2
+        echo "Invalid APP_PROCESS_TYPE: $process_type. Expected 'server', 'worker', or 'mcp'." >&2
         exit 1
         ;;
 esac

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -59,6 +59,27 @@ services:
     env_file:
       - .env
 
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile-python
+    working_dir: /app
+    command: uv run --no-sync python mcp_http_server.py
+    volumes:
+      - .:/app
+    ports:
+      - "8765:8765"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    env_file:
+      - .env
+    environment:
+      MCP_HOST: 0.0.0.0
+      MCP_PORT: 8765
+
   frontend:
     image: node:24.15.0
     working_dir: /app

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -49,6 +49,21 @@ services:
     env_file:
       - .env
 
+  mcp:
+    image: "${APP_IMAGE:-osig:latest}"
+    working_dir: /app
+    ports:
+      - "8765:80"
+    environment:
+      APP_PROCESS_TYPE: mcp
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    env_file:
+      - .env
+
 volumes:
   postgres_data:
   redis_data:

--- a/docs/agent-mcp.md
+++ b/docs/agent-mcp.md
@@ -1,54 +1,103 @@
-# OSIG Agent MCP
+# Agent MCP Usage
 
-OSIG exposes a hosted FastMCP server for agents that need to iterate on generated Open Graph images.
+Use OSIG's MCP server when an AI agent needs to inspect image options, render previews, and publish a stable `/g` image URL.
 
-The server is intentionally small and explicit. It does not expose generic database access or arbitrary file access. The tools wrap the existing image renderer, signing helpers, and render metrics so future improvements stay close to the Django source of truth.
+This guide is for agents and agent-client setup. Human website usage is in [human-usage.md](human-usage.md).
 
 ## Hosted Endpoint
 
-Production serves MCP at:
+Production MCP endpoint:
 
 ```text
 https://osig.app/mcp/
 ```
 
-Hosted requests require an OSIG profile key in either header:
+No authentication headers are required during the current trial.
 
-```text
-X-API-Key: <profile-key>
-Authorization: Bearer <profile-key>
+Example MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "osig": {
+      "url": "https://osig.app/mcp/"
+    }
+  }
+}
 ```
 
-The web process serves `/mcp/` through ASGI in the same container as Django, matching the `django-saas-starter` hosted MCP pattern.
-The production server command runs `gunicorn osig.asgi:application` with `uvicorn_worker.UvicornWorker`; no separate MCP container is required.
+## Local HTTP Server
 
-## Run Locally
+Local commands expect the normal Django environment. If you do not already have `.env`, start from the example:
 
-For stdio clients:
+```bash
+cp .env.example .env
+```
+
+For native local runs without Docker Postgres, set `DATABASE_URL=sqlite:///db.sqlite3` in `.env`.
+
+Run the standalone FastMCP Streamable HTTP server:
+
+```bash
+uv run python mcp_http_server.py
+```
+
+Default local endpoint:
+
+```text
+http://127.0.0.1:8765/mcp
+```
+
+Override host, port, or path with:
+
+```bash
+MCP_HOST=0.0.0.0 MCP_PORT=8765 MCP_PATH=/mcp uv run python mcp_http_server.py
+```
+
+## Local Stdio Server
+
+For stdio-based clients:
 
 ```bash
 uv run python mcp_server.py
 ```
 
-For clients that inspect a server before connecting:
+Inspect the tool list:
 
 ```bash
 uv run fastmcp list --command "uv run python mcp_server.py"
 ```
 
-The stdio entrypoint uses `DJANGO_SETTINGS_MODULE=osig.settings` and calls `django.setup()` before loading `core.mcp`. It expects the same environment as the Django app, either through `.env` or exported shell variables.
+If you are passing ad hoc environment values instead of using `.env`, put them inside the spawned command string:
 
-When using `fastmcp list --command` with ad hoc local settings instead of a `.env` file, put those environment variables inside the command string so the spawned stdio server receives them.
+```bash
+uv run fastmcp list --command "sh -c 'set -a; . ./.env.example; set +a; uv run python mcp_server.py'"
+```
 
 ## Tools
 
-- `get_image_generation_contract`: styles, valid choices, dimensions, fields, and the recommended iteration workflow.
+- `get_image_generation_contract`: returns styles, choices, dimensions, fields, and the recommended workflow.
 - `normalize_image_params`: canonicalizes renderer inputs and maps `image_or_logo` to `image_url`.
 - `render_image_preview`: renders a preview and returns metadata plus optional base64 image bytes.
-- `build_signed_image_url`: creates a tamper-proof public `/g` URL.
-- `list_recent_generated_images`: returns capped summaries of persisted images scoped to a required profile key.
-- `get_recent_render_metrics`: returns recent render attempt health metrics. Hosted HTTP calls require a superuser profile key.
+- `build_signed_image_url`: creates a signed public `/g` URL.
+- `list_recent_generated_images`: returns recent persisted images for an explicit OSIG profile key.
 
-## Transport Notes
+Admin render metrics are not exposed through the unauthenticated MCP server.
 
-The default entrypoint is stdio because this is meant for local/editor agents. If this becomes a remote service, run it as a private HTTP sidecar rather than mounting it into the current WSGI deployment, then add authentication before exposing it beyond trusted infrastructure.
+## Recommended Agent Workflow
+
+1. Call `get_image_generation_contract`.
+2. Choose `style`, `site`, `font`, and copy fields.
+3. Call `normalize_image_params` to catch canonical params and warnings.
+4. Call `render_image_preview` while iterating.
+5. Call `build_signed_image_url` once the preview is ready to publish.
+6. Put the returned URL in `og:image`, `twitter:image`, and schema image fields.
+
+## Serving Model
+
+OSIG serves MCP through FastMCP in two ways:
+
+- ASGI mount: `osig/asgi.py` mounts `mcp.http_app(path="/")` at `/mcp` beside Django.
+- Sidecar: `mcp_http_server.py` runs the same FastMCP server as a separate Streamable HTTP process.
+
+The ASGI mount requires an async server such as Gunicorn with `uvicorn_worker.UvicornWorker`.

--- a/docs/human-usage.md
+++ b/docs/human-usage.md
@@ -1,0 +1,66 @@
+# Human Usage
+
+Use OSIG when you want a stable social preview image URL for a website page.
+
+## Image URL
+
+All generated images use:
+
+```text
+https://osig.app/g
+```
+
+Add query parameters to control the rendered image:
+
+```text
+https://osig.app/g?site=x&style=base&font=helvetica&title=Hello&subtitle=Short%20description
+```
+
+## Common Parameters
+
+- `title`: main text.
+- `subtitle`: supporting text.
+- `eyebrow`: small label above the title.
+- `image_url`: background image or logo URL.
+- `image_or_logo`: alias for `image_url`, useful for job-board templates.
+- `style`: `base`, `logo`, `job_classic`, `job_logo`, or `job_clean`.
+- `site`: `x` or `meta`.
+- `font`: `helvetica`, `markerfelt`, or `papyrus`.
+- `format`: `png` or `jpeg`.
+- `quality`: `1` to `100`, mostly useful for JPEG.
+- `max_kb`: best-effort JPEG size target.
+- `v`: cache-busting version token.
+
+## Meta Tags
+
+Use the generated URL in Open Graph and Twitter/X tags:
+
+```html
+<meta property="og:image" content="https://osig.app/g?site=x&style=base&title=Hello" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="https://osig.app/g?site=x&style=base&title=Hello" />
+```
+
+## Examples
+
+Article preview:
+
+```text
+https://osig.app/g?site=x&style=base&font=helvetica&title=10%20Years%20of%20Great%20Books&subtitle=A%20reading%20plan&eyebrow=Article&image_url=https://example.com/cover.png
+```
+
+Job preview:
+
+```text
+https://osig.app/g?site=x&style=job_logo&font=helvetica&title=Senior%20Django%20Engineer&subtitle=Build%20reliable%20product%20features&eyebrow=Remote%20Full-time&image_or_logo=https://example.com/company-logo.png
+```
+
+## Cache Refresh
+
+Social platforms cache images aggressively. When the image should change, update the `v` parameter:
+
+```text
+https://osig.app/g?title=Hello&v=2026-06-09
+```
+
+Unsigned `/g` URLs remain supported so existing templates keep working.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
-# Hello
+# OSIG Documentation
 
-I'm glad you decided to give my boilerplate a go. I recommend you star with the "[Getting Started](/getting-started)" section.
+OSIG has two usage paths:
+
+- [Human Usage](human-usage.md): use `/g` image URLs in website meta tags.
+- [Agent MCP Usage](agent-mcp.md): connect AI agents to OSIG through FastMCP.

--- a/frontend/templates/pages/how-to.html
+++ b/frontend/templates/pages/how-to.html
@@ -4,16 +4,16 @@
 {% block meta %}
 {% site_url request.path as page_url %}
 {% absolute_static "vendors/images/logo-square.png" as logo_square_url %}
-{% og_image_url "How to Generate Open Graph Images" "Learn how to create and add OSIG social preview images to your site with URL parameters, agent MCP workflows, and examples." image_url=logo_square_url as page_og_image %}
+{% og_image_url "How to Generate Open Graph Images" "Learn how to create and add OSIG social preview images to your site with URL parameters and examples." image_url=logo_square_url as page_og_image %}
 <title>How to Generate Open Graph Images | OSIG</title>
-<meta name="description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, MCP tools, and integration notes." />
+<meta name="description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, and integration notes." />
 <meta name="robots" content="index, follow" />
 <link rel="canonical" href="{{ page_url }}" />
 
 <meta property="og:type" content="website" />
 <meta property="og:title" content="How to Generate Open Graph Images | OSIG" />
 <meta property="og:url" content="{{ page_url }}" />
-<meta property="og:description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, MCP tools, and integration notes." />
+<meta property="og:description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, and integration notes." />
 <meta property="og:image" content="{{ page_og_image }}" />
 <meta property="og:locale" content="en_US" />
 
@@ -21,7 +21,7 @@
 <meta name="twitter:creator" content="@rasulkireev" />
 <meta name="twitter:site" content="@rasulkireev" />
 <meta name="twitter:title" content="How to Generate Open Graph Images | OSIG" />
-<meta name="twitter:description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, MCP tools, and integration notes." />
+<meta name="twitter:description" content="Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, and integration notes." />
 <meta name="twitter:image" content="{{ page_og_image }}" />
 {% endblock meta %}
 
@@ -34,7 +34,6 @@
       <a href="#examples" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Examples</a>
       <a href="#output-controls" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Output controls</a>
       <a href="#signed-urls" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Signed URLs</a>
-      <a href="#mcp" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Using the MCP</a>
       <a href="#meta-tags" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Meta tags</a>
       <a href="#validation" class="nav-link block rounded-md px-3 py-2 hover:bg-[var(--osig-surface-soft)]">Validation</a>
     </div>
@@ -171,31 +170,6 @@
   "expires_in_seconds": 3600
 }</code></pre>
 
-      <h2 id="mcp">Using the MCP</h2>
-      <p>OSIG exposes a Model Context Protocol server for agent clients that need to inspect options, render previews, and build signed image URLs.</p>
-      <ol>
-        <li>Get your profile key from the <a class="link" href="{% url 'settings' %}">settings page</a>.</li>
-        <li>Connect your MCP client to <code>https://osig.app/mcp/</code>.</li>
-        <li>Authenticate with <code>X-API-Key: &lt;profile-key&gt;</code> or <code>Authorization: Bearer &lt;profile-key&gt;</code>.</li>
-        <li>Call <code>get_image_generation_contract</code> first to inspect styles, fields, dimensions, and the recommended workflow.</li>
-      </ol>
-      <pre class="code-block"><code>{
-  "mcpServers": {
-    "osig": {
-      "url": "https://osig.app/mcp/",
-      "headers": {
-        "X-API-Key": "YOUR_OSIG_PROFILE_KEY"
-      }
-    }
-  }
-}</code></pre>
-      <p>A useful agent workflow is to normalize parameters, render previews while iterating, build a signed URL, then place that URL in your Open Graph and Twitter image tags.</p>
-      <pre class="code-block"><code>normalize_image_params
-render_image_preview
-build_signed_image_url</code></pre>
-      <p>For local development with this repository checked out, run the stdio server.</p>
-      <pre class="code-block"><code>uv run python mcp_server.py</code></pre>
-
       <h2 id="meta-tags">Meta tags</h2>
       <p>Use the generated image URL in Open Graph and Twitter card metadata.</p>
       <pre class="code-block"><code>&lt;meta property="og:image" content="{ generated_image_url }" /&gt;
@@ -261,7 +235,7 @@ build_signed_image_url</code></pre>
     "@context": "https://schema.org",
     "@type": "HowTo",
     "name": "How to Generate Open Graph Images with OSIG",
-    "description": "Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, MCP tools, and integration notes.",
+    "description": "Learn how to generate Open Graph and Twitter card images with OSIG URL parameters, examples, styles, fonts, and integration notes.",
     "url": "{{ page_url }}",
     "author": {
       "@type": "Person",

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -1,0 +1,24 @@
+# ruff: noqa: E402
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "osig.settings")
+
+import django
+
+django.setup()
+
+from core.mcp import mcp
+
+
+def _port() -> int:
+    return int(os.getenv("MCP_PORT") or os.getenv("PORT") or "8765")
+
+
+if __name__ == "__main__":
+    mcp.run(
+        transport="http",
+        host=os.getenv("MCP_HOST", "127.0.0.1"),
+        port=_port(),
+        path=os.getenv("MCP_PATH", "/mcp"),
+    )

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -1,24 +1,26 @@
-# ruff: noqa: E402
-
 import os
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "osig.settings")
-
-import django
-
-django.setup()
-
-from core.mcp import mcp
 
 
 def _port() -> int:
-    return int(os.getenv("MCP_PORT") or os.getenv("PORT") or "8765")
+    return int(os.getenv("MCP_PORT", "8765"))
 
 
-if __name__ == "__main__":
+def main() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "osig.settings")
+
+    import django
+
+    django.setup()
+
+    from core.mcp import mcp
+
     mcp.run(
         transport="http",
         host=os.getenv("MCP_HOST", "127.0.0.1"),
         port=_port(),
         path=os.getenv("MCP_PATH", "/mcp"),
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,4 +9,5 @@ plugins:
 nav:
   - index.md
   - getting-started.md
+  - human-usage.md
   - agent-mcp.md

--- a/osig/asgi.py
+++ b/osig/asgi.py
@@ -20,10 +20,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "osig.settings")
 django_application = get_asgi_application()
 
 from core.mcp import mcp  # noqa: E402
-from core.mcp_auth import McpAuthMiddleware  # noqa: E402
 
-raw_mcp_application = mcp.http_app(path="/")
-mcp_application = McpAuthMiddleware(raw_mcp_application)
+mcp_application = mcp.http_app(path="/")
 
 
 def redirect_mcp(request: Request) -> RedirectResponse:
@@ -36,5 +34,5 @@ application = Starlette(
         Mount("/mcp", app=mcp_application),
         Mount("/", app=django_application),
     ],
-    lifespan=raw_mcp_application.lifespan,
+    lifespan=mcp_application.lifespan,
 )


### PR DESCRIPTION
## Summary
- expose the FastMCP ASGI mount without auth middleware for the current trial
- add a standalone FastMCP HTTP sidecar entrypoint and compose/process support
- split human /g usage docs from agent MCP setup docs
- remove admin render metrics from the public unauthenticated MCP tool list

## Test Plan
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DJANGO_SETTINGS_MODULE=osig.settings DATABASE_URL=sqlite:////tmp/osig-test-full-rebased.sqlite3 REDIS_URL=redis://localhost:6379/0 ALLOWED_HOSTS=localhost,127.0.0.1,testserver,osig.app uv run pytest -p pytest_django.plugin
- uv run fastmcp list --command "sh -c 'set -a; . ./.env.example; set +a; DATABASE_URL=sqlite:////tmp/osig-test-mcp-rebased.sqlite3 REDIS_URL=redis://localhost:6379/0 ALLOWED_HOSTS=localhost,127.0.0.1,testserver,osig.app uv run python mcp_server.py'"