### PR TITLE
[Docs] Add Agent-First Steering Files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,116 @@
+# OSIG Agent Guide
+
+## Scope
+
+This file is the vendor-neutral operating manual for AI coding agents working in this repository. Read it with `PRODUCT.md`, `VISION.md`, `TECH.md`, `STRUCTURE.md`, and `DESIGN.md` before making product or architectural changes.
+
+## Project Summary
+
+OSIG is the Open Source Social Image Generator. The long-term direction is AI-agent-first image infrastructure: agents should be able to discover supported image templates, provide structured text and asset inputs, render deterministic previews, and either save image bytes into a project or create signed public Open Graph image URLs.
+
+The hosted cloud product should be paid by default for production use. The repository remains open source and self-hostable, but hosted MCP/API access should not become an unlimited free utility.
+
+## Product Direction
+
+- Treat MCP and API workflows as the primary product surface.
+- Treat the web UI as a playground, docs, account, billing, and diagnostics surface.
+- Treat `/g` as a rendering and backwards-compatibility endpoint, not the main product concept for future work.
+- Prefer deterministic code-generated images over model-generated images. The value is cost, repeatability, speed, and easy repo integration for agents.
+- Start with Open Graph and social preview images, but keep boundaries clean enough for future code-generated image types.
+
+## Reliable Commands
+
+Install and run through Docker when possible:
+
+```bash
+cp .env.example .env
+make serve
+```
+
+Run the Django shell:
+
+```bash
+make shell
+```
+
+Run migrations:
+
+```bash
+make migrate
+make makemigrations
+```
+
+Run tests:
+
+```bash
+make test
+make test core/tests/test_mcp.py
+make test core/tests/test_generate_image_features.py
+```
+
+Run the local stdio MCP server:
+
+```bash
+uv run python mcp_server.py
+```
+
+Inspect the local MCP tool contract:
+
+```bash
+uv run fastmcp list --command "uv run python mcp_server.py"
+```
+
+Build frontend assets:
+
+```bash
+npm run build
+```
+
+## Development Workflow
+
+- Use `rg` for code search.
+- Read the existing implementation before changing behavior. The most important files are listed in `STRUCTURE.md`.
+- Keep changes close to existing module boundaries.
+- Add or update tests for behavior changes, especially MCP tools, `/g`, signing, usage quota, auth, and render error handling.
+- Prefer `make test <path>` for focused verification and `make test` before finishing larger work.
+- Do not stage unrelated files or revert user changes.
+
+## AI-Agent-First Rules
+
+- Tool contracts should be typed, discoverable, and safe for autonomous use.
+- MCP tools should return machine-readable metadata, warnings, hashes, content types, dimensions, and stable URLs where useful.
+- When adding image inputs, make them model-friendly: named fields, explicit enum choices, bounded text lengths, and clear validation errors.
+- Keep preview and publish flows separate. Agents should be able to iterate cheaply, then create a signed public URL only when ready.
+- Do not add arbitrary filesystem, shell, database, or admin tools to hosted MCP.
+- Hosted MCP requests must stay authenticated with profile keys via `X-API-Key` or `Authorization: Bearer <key>`.
+- Public URL parameters should use `key`, not `profile_id`.
+
+## Pricing And Access Rules
+
+- Open source/self-hosted usage can be free.
+- Hosted production usage should require an account and paid entitlement.
+- Watermarking is the default unpaid/free enforcement mechanism for rendered images.
+- Quotas should remain visible and enforceable through profile usage records and response headers.
+- Do not introduce new unlimited free hosted paths around watermark, quota, signing, or MCP authentication.
+- Any free trial or demo should be deliberately bounded by quota, watermark, expiration, or non-production scope.
+
+## Risky Actions
+
+Ask for explicit approval before:
+
+- Removing or breaking current public `/g` behavior without a migration plan.
+- Weakening signature verification, MCP auth, API key handling, quotas, or watermark rules.
+- Exposing generated images, profile keys, customer data, or render history across profiles.
+- Adding new paid-plan behavior without making entitlement and failure states clear.
+- Replacing deterministic rendering with model image generation as the default path.
+- Changing deployment roles, CapRover app names, storage backends, or Stripe/dj-stripe behavior.
+
+## Review Expectations
+
+Before finishing meaningful changes, verify:
+
+- MCP/API contracts still support agent-first discovery, preview, and publish flows.
+- `/g` compatibility is preserved or intentionally documented as changed.
+- Generated image layouts handle long text, missing images, invalid image URLs, and both `x` and `meta` dimensions.
+- Quota, watermark, and signed URL behavior match `PRODUCT.md` and `TECH.md`.
+- Docs and steering files stay in sync with code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,8 @@ npm run build
 - When adding image inputs, make them model-friendly: named fields, explicit enum choices, bounded text lengths, and clear validation errors.
 - Keep preview and publish flows separate. Agents should be able to iterate cheaply, then create a signed public URL only when ready.
 - Do not add arbitrary filesystem, shell, database, or admin tools to hosted MCP.
-- Hosted MCP requests must stay authenticated with profile keys via `X-API-Key` or `Authorization: Bearer <key>`.
+- The current hosted MCP surface is an unauthenticated trial. Do not expose private, admin, billing, or cross-profile tools while it remains public.
+- Reintroduce profile-key authentication before treating hosted MCP as a paid production surface.
 - Public URL parameters should use `key`, not `profile_id`.
 
 ## Pricing And Access Rules
@@ -92,14 +93,14 @@ npm run build
 - Watermarking is the default unpaid/free enforcement mechanism for rendered images.
 - Quotas should remain visible and enforceable through profile usage records and response headers.
 - Do not introduce new unlimited free hosted paths around watermark, quota, signing, or MCP authentication.
-- Any free trial or demo should be deliberately bounded by quota, watermark, expiration, or non-production scope.
+- Any free trial or demo, including the current unauthenticated MCP trial, should be deliberately bounded by quota, watermark, expiration, limited tool scope, or non-production positioning.
 
 ## Risky Actions
 
 Ask for explicit approval before:
 
 - Removing or breaking current public `/g` behavior without a migration plan.
-- Weakening signature verification, MCP auth, API key handling, quotas, or watermark rules.
+- Weakening signature verification, API key handling, quotas, watermark rules, or expanding unauthenticated MCP scope.
 - Exposing generated images, profile keys, customer data, or render history across profiles.
 - Adding new paid-plan behavior without making entitlement and failure states clear.
 - Replacing deterministic rendering with model image generation as the default path.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,14 +2,25 @@
 
 ## Summary
 
-OSIG uses a restrained product UI system for a public utility site. The interface should make the generator, documentation, onboarding wizard, pricing, and account settings feel like one practical workflow.
+OSIG uses a restrained technical UI system for agent-first image infrastructure. The product should feel like a reliable developer tool: clear contracts, visible examples, copyable code, predictable billing, and fast diagnostics.
+
+The generated images are also part of the product design. They should look polished enough for production social previews while remaining deterministic, template-driven, and safe under long text or missing assets.
+
+## Interface Priority
+
+- Lead with the agent/MCP/API workflow over a human hand-tuned generator.
+- Use the web UI for setup, API keys, docs, playground previews, usage, billing, and render health.
+- Keep the generator and onboarding wizard as useful playgrounds, not as the only way to understand the product.
+- Prefer tables, code blocks, parameter inspectors, previews, and status panels over marketing sections.
+- Make paid/free state, watermark behavior, quota, and signed URL expiry visible.
 
 ## Visual Theme
 
 - Mood: clear technical workspace, calm publishing utility, direct copy.
 - Surfaces: light neutral background, white working panels, soft secondary panels for supporting context.
 - Shape: 8px radius for panels, controls, previews, and repeated items.
-- Chrome: borders over shadows; use framing only where it helps identify a tool, form, preview, or plan.
+- Chrome: borders over shadows; use framing only where it helps identify a tool, form, preview, code sample, or plan.
+- Density: practical and scannable. Avoid oversized marketing compositions unless redesigning the public homepage intentionally.
 
 ## Color
 
@@ -18,15 +29,23 @@ Tokens live in `frontend/src/styles/index.css` and use OKLCH values.
 - `--osig-bg`: page background.
 - `--osig-surface`: primary content surface.
 - `--osig-surface-soft`: secondary surface.
+- `--osig-surface-tint`: subtle inline code and inactive step backgrounds.
 - `--osig-ink`: primary text.
 - `--osig-muted`: body and helper text.
+- `--osig-soft`: low-emphasis labels and status text.
+- `--osig-line`: borders.
 - `--osig-accent`: primary action blue.
+- `--osig-accent-strong`: links, hover states, and strong actions.
+- `--osig-accent-soft`: selected states and light callouts.
 - `--osig-olive` and `--osig-amber`: logo-informed supporting colors.
 - `--osig-danger`, `--osig-success`, `--osig-warning`: semantic states.
+- `--osig-code`: code block background.
 
 ## Typography
 
-Use the system sans stack for all product UI. Headings rely on weight and compact tracking, not decorative fonts. Body copy should stay direct and specific, with line lengths capped on documentation and article surfaces.
+Use the system sans stack for all product UI. Headings rely on weight and hierarchy, not decorative fonts. Body copy should stay direct and specific, with line lengths capped on documentation and article surfaces.
+
+Do not use viewport-width font scaling. Keep letter spacing at `0` in new compact UI; existing display headings can keep their current styling unless being redesigned.
 
 ## Components
 
@@ -35,11 +54,28 @@ Use the system sans stack for all product UI. Headings rely on weight and compac
 - Layout: `.site-container`, `.site-container-narrow`, `.panel`, `.panel-soft`.
 - Content: `.page-kicker`, `.page-title`, `.section-title`, `.lede`, `.doc-prose`, `.code-block`.
 - Workflow: `.step-pill`, `.wizard-step-indicator`.
+- Preview: `.preview-frame`.
+
+Add new component classes only when the pattern repeats across pages. For one-off layouts, prefer Tailwind utility classes in the template.
+
+## Generated Image Design
+
+- Templates should be text-safe first: clamp, wrap, or truncate deliberately.
+- Always test both `x` and `meta` dimensions.
+- Missing `image_url` should produce a deliberate fallback, not a broken layout.
+- Invalid remote images should fail or degrade consistently according to renderer behavior.
+- Watermarks should be legible but not destructive; paid output should remove them cleanly.
+- Avoid visual styles that look like generic AI art. The product promise is code-generated reliability.
+- New templates should document their intended content type, required/optional fields, and truncation behavior.
 
 ## Interaction
 
-Motion is limited to short state transitions on navigation, buttons, dropdowns, wizard progress, generator status, and toasts. Reduced motion users receive instant or near-instant transitions. Generated preview and wizard states should always communicate what is happening in text, not color alone.
+Motion is limited to short state transitions on navigation, buttons, dropdowns, wizard progress, generator status, and toasts. Reduced motion users receive instant or near-instant transitions.
+
+Preview, quota, billing, validation, and wizard states should always communicate what is happening in text, not color alone. Errors should name the failing input or system boundary.
 
 ## Accessibility
 
 Target WCAG AA contrast, visible focus states, keyboard reachable controls, semantic sections, useful button labels, and non-color state indicators. Keep generated URLs and code blocks copyable and horizontally scrollable on small screens.
+
+Agent-facing JSON and docs should be accessible in the practical sense: stable field names, concise descriptions, copyable examples, and machine-readable enum choices.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,33 +1,71 @@
 # Product
 
-## Register
+## Summary
 
-product
+OSIG is AI-agent-first infrastructure for generating deterministic social preview images from structured text, remote assets, and reusable code templates. The product lets an AI agent avoid expensive model image generation when the needed output is a clean Open Graph or Twitter card image.
+
+The current app already supports URL rendering, signed URLs, a hosted FastMCP server, a local stdio MCP entrypoint, usage metering, quotas, Stripe subscriptions, and render observability. Future product work should make the MCP/API workflow the primary experience and keep the web UI focused on setup, docs, billing, examples, and diagnostics.
 
 ## Users
 
-OSIG is for developers, founders, publishers, and small teams who need Open Graph and Twitter card images without opening a design tool for every page. They are usually in a publishing or integration flow: making a page share correctly, preparing a job post, wiring metadata into a CMS, or creating signed image URLs for repeatable use.
+Primary users are AI agents working on behalf of developers, founders, publishers, indie hackers, marketers, and small teams. The agent needs to generate an image asset, embed an OG URL, or update repository metadata without asking a human to open a design tool.
 
-## Product Purpose
+Secondary users are humans configuring accounts, API keys, billing, self-hosting, templates, and validation. They need confidence that the generated image will be stable, cheap, and social-platform-ready.
 
-OSIG creates dynamic social preview images from URL parameters, signed API calls, and a guided onboarding flow. Success means a user can understand the available inputs, generate a useful image URL, copy the right metadata, and validate the result with minimal uncertainty.
+## Problem
+
+Agents can ask image models to generate social preview images, but that is often expensive, slow, inconsistent, and hard to revise precisely. Most OG images need layout, typography, background/logo placement, dimensions, and text handling more than they need generative art.
+
+OSIG should give agents a cheaper path: provide text and parameters, render with code, inspect the result, and publish the output as bytes or a signed URL.
+
+## Core Workflows
+
+- Agent discovers the image contract with MCP, chooses a template, normalizes parameters, renders previews, then saves a PNG/JPEG or creates a signed public URL.
+- Agent updates a website repository by generating OG metadata, preview images, cache-busting versions, and validation links.
+- Human signs up, retrieves an API key, checks usage/quota, manages billing, and reads integration docs.
+- Self-hoster runs the open source app and adapts templates for private use.
+- Admin investigates render failure rate, p95 render time, and recent generated images.
+
+## What Good Looks Like
+
+- An agent can generate a useful image without browsing the web UI.
+- The available styles, dimensions, fields, defaults, warnings, and publish steps are machine-readable.
+- Preview generation is cheap and repeatable.
+- Final output is deterministic, cacheable, and safe to embed in production metadata.
+- The hosted product makes paid access, watermark behavior, quotas, and entitlement states obvious.
+- The codebase stays self-hostable and open source without making hosted cloud usage unlimited or free by default.
+
+## Pricing Posture
+
+OSIG cloud should be paid for production use. The open source code can remain free to run independently, but hosted MCP/API rendering should require an account and should be bounded by quota, watermark, expiration, or subscription state.
+
+The default unpaid behavior is watermarking. Paid plans should remove watermarks and raise hosted usage limits. Free/demo access, if offered, should exist only to prove the workflow and should not become an unmetered production image CDN.
+
+## In Scope
+
+- MCP and API tools for image contract discovery, normalization, preview rendering, signed URL creation, recent image listing, and render metrics.
+- Open Graph and social preview templates, starting with article, logo, and job-board styles.
+- Deterministic code-rendered PNG/JPEG output.
+- Usage metering, quota enforcement, paid access, watermarking, and signed URL workflows.
+- Human-facing setup, docs, playground, billing, account, validation, and observability screens.
+- CMS/helper integrations when they map common content fields into OSIG's structured parameters.
+
+## Out Of Scope
+
+- Defaulting to model-generated images.
+- A general-purpose design editor.
+- A free unlimited hosted image rendering/CDN service.
+- Arbitrary remote control through MCP, such as database browsing, shell execution, or file access.
+- Complex brand-management suites until the agent-first OG workflow is clearly working.
 
 ## Brand Personality
 
-Clear, practical, builder-focused. The product should feel direct and useful before it feels polished. The voice should explain exactly what will happen, name constraints plainly, and keep momentum toward a working preview image.
+Clear, practical, technical, and reliable. OSIG should sound like a tool an agent can use safely: specific inputs, explicit constraints, predictable results, and no vague marketing language.
 
-## Anti-references
+## Success Criteria
 
-Avoid generic SaaS presentation patterns that bury the working generator under vague marketing copy. Avoid dense documentation pages that make the user assemble the workflow from scattered parameter notes. Avoid visual treatments that make OSIG feel like a novelty toy instead of a reliable publishing utility.
-
-## Design Principles
-
-- Put the working path first: every important page should move the user toward generating, copying, signing, or validating an image URL.
-- Prefer specific labels over mood copy: headings, buttons, and helper text should say what the user can do next.
-- Make examples inspectable: previews, code, parameters, and validation links should be easy to compare and copy.
-- Keep the interface calm: use visual hierarchy, spacing, and restrained color to reduce uncertainty.
-- Preserve technical trust: forms, docs, pricing, and settings should feel consistent and predictable.
-
-## Accessibility & Inclusion
-
-Target WCAG AA contrast for text and controls. Support keyboard navigation and visible focus states on all interactive elements. Respect reduced motion preferences. Do not rely on color alone for state, validation, or pricing emphasis.
+- Agents can complete the discover, preview, publish loop with MCP alone.
+- Hosted usage converts to paid plans because it is cheaper than model generation and easier than custom image code.
+- Render failures are observable and actionable.
+- New templates are easy to test against long text, missing images, invalid remote assets, and both supported dimensions.
+- Human users understand the difference between open source self-hosting and paid hosted cloud access.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -43,7 +43,8 @@ The default unpaid behavior is watermarking. Paid plans should remove watermarks
 
 ## In Scope
 
-- MCP and API tools for image contract discovery, normalization, preview rendering, signed URL creation, recent image listing, and render metrics.
+- MCP tools for image contract discovery, normalization, preview rendering, signed URL creation, and recent image listing.
+- API endpoints for render metrics and integration helpers that should not be exposed as unauthenticated MCP tools.
 - Open Graph and social preview templates, starting with article, logo, and job-board styles.
 - Deterministic code-rendered PNG/JPEG output.
 - Usage metering, quota enforcement, paid access, watermarking, and signed URL workflows.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,80 @@
+# Structure
+
+## Directory Map
+
+- `core/`: main Django app for product logic, API endpoints, rendering, MCP, usage, billing hooks, and tests.
+- `core/api/`: Django Ninja API schemas, views, and auth helpers.
+- `core/tests/`: pytest coverage for renderer behavior, MCP, auth, onboarding, quotas, views, reliability, and integrations.
+- `frontend/src/`: JavaScript controllers and CSS entrypoint.
+- `frontend/templates/`: Django templates for pages, account flows, components, blog, and base layout.
+- `frontend/vendors/images/`: static product/logo/example images.
+- `fonts/`: bundled fonts used by the Pillow renderer.
+- `docs/`: project and feature documentation.
+- `osig/`: Django project settings, URLs, ASGI/WSGI, sitemap, and logging utilities.
+- `deployment/`: production Dockerfile and entrypoint.
+- `.github/workflows/`: deployment workflow.
+- `mcp_server.py`: local stdio MCP entrypoint.
+
+## Important Files
+
+- `core/mcp.py`: MCP contract and tool implementation.
+- `core/mcp_auth.py`: hosted MCP API-key authentication.
+- `core/image_styles.py`: image style router and template renderers.
+- `core/image_utils.py`: dimensions, font loading, image fetching, output encoding, watermark helper.
+- `core/views.py`: public pages and `/g` renderer endpoint.
+- `core/api/views.py`: signed URL, onboarding metadata, WordPress helper, blog submission, render metrics.
+- `core/models.py`: profiles, usage, generated images, render attempts, blog posts.
+- `core/usage.py`: per-profile usage metering and quota enforcement.
+- `core/render_observability.py`: render error taxonomy, retry classification, aggregate metrics.
+- `core/signing.py`: signed public URL creation and verification.
+- `frontend/src/controllers/image_generator_controller.js`: current human web generator.
+- `frontend/src/controllers/onboarding_wizard_controller.js`: guided human metadata workflow.
+- `frontend/src/styles/index.css`: product UI tokens and component classes.
+- `deployment/entrypoint.sh`: production server/worker role selection.
+
+## Ownership Boundaries
+
+- MCP changes belong in `core/mcp.py` unless they require shared auth/render/signing behavior.
+- Public JSON API changes belong in `core/api/`.
+- Render template changes belong in `core/image_styles.py`; shared image mechanics belong in `core/image_utils.py`.
+- `/g` request parsing and response/cache behavior belong in `core/views.py`.
+- New persisted state belongs in `core/models.py` with migrations and admin/test updates.
+- Human UI changes should use Django templates, Stimulus controllers, and CSS tokens already present in `frontend/src/styles/index.css`.
+- Product direction belongs in root steering files, not scattered only through feature docs.
+
+## Placement Rules
+
+- Add new tests beside related existing tests under `core/tests/`.
+- Add new image styles to the router, MCP contract, README/docs, and test coverage in one change.
+- Add new public API request/response shapes to `core/api/schemas.py`.
+- Add new API endpoints to `core/api/views.py` and route through the existing Ninja API.
+- Add new CSS component primitives in `frontend/src/styles/index.css` only when repeated across pages.
+- Add generated/static example assets to `frontend/vendors/images/` only when they are durable docs/product assets.
+- Add operational docs to `docs/`, but keep durable AI-agent steering at the repository root.
+
+## Import And Naming Patterns
+
+- Prefer explicit imports from local modules.
+- Keep Django settings access through `django.conf.settings`.
+- Use existing helper names and public parameter names: `style`, `site`, `font`, `title`, `subtitle`, `eyebrow`, `image_url`, `image_or_logo`, `format`, `quality`, `max_kb`, `v`, `key`.
+- Use `profile_id` only internally after authenticating or resolving a `Profile`.
+- Keep public enum values stable unless there is a migration plan.
+
+## Cross-Cutting Checks
+
+When touching renderer, MCP, API, billing, or quota behavior, check these paths together:
+
+- `core/mcp.py`
+- `core/views.py`
+- `core/api/views.py`
+- `core/image_styles.py`
+- `core/image_utils.py`
+- `core/tests/`
+- `README.md`
+- `docs/agent-mcp.md`
+- `PRODUCT.md`
+- `TECH.md`
+
+## Current Product Surfaces
+
+The web generator and onboarding wizard are useful, but they are not the long-term center of the product. Future structure should make it easy for agents to call MCP/API flows directly while humans use the web app for configuration, billing, docs, and diagnostics.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -14,11 +14,12 @@
 - `deployment/`: production Dockerfile and entrypoint.
 - `.github/workflows/`: deployment workflow.
 - `mcp_server.py`: local stdio MCP entrypoint.
+- `mcp_http_server.py`: standalone FastMCP Streamable HTTP sidecar entrypoint.
 
 ## Important Files
 
 - `core/mcp.py`: MCP contract and tool implementation.
-- `core/mcp_auth.py`: hosted MCP API-key authentication.
+- `core/mcp_auth.py`: profile-key MCP auth helpers; not currently mounted on the public trial MCP surface.
 - `core/image_styles.py`: image style router and template renderers.
 - `core/image_utils.py`: dimensions, font loading, image fetching, output encoding, watermark helper.
 - `core/views.py`: public pages and `/g` renderer endpoint.

--- a/TECH.md
+++ b/TECH.md
@@ -37,7 +37,8 @@ uv run fastmcp list --command "uv run python mcp_server.py"
 
 ## Primary Product Interfaces
 
-- Hosted MCP: `/mcp/`, authenticated with `X-API-Key` or `Authorization: Bearer <key>`.
+- Hosted MCP trial: `/mcp/`, currently public/unauthenticated for agent experimentation.
+- Standalone local MCP HTTP sidecar: `uv run python mcp_http_server.py`.
 - Local MCP stdio: `uv run python mcp_server.py`.
 - Public render endpoint: `/g`.
 - Signed URL API: `POST /api/sign`.
@@ -56,9 +57,10 @@ Current tools:
 - `render_image_preview`
 - `build_signed_image_url`
 - `list_recent_generated_images`
-- `get_recent_render_metrics`
 
-Keep MCP tools narrow, typed, and deterministic. They should wrap existing renderer/signing/metrics behavior rather than becoming a separate product implementation.
+Admin render metrics are REST-only at `GET /api/admin/render-metrics`; do not list them as MCP tools while hosted MCP remains public and unauthenticated.
+
+Keep MCP tools narrow, typed, and deterministic. They should wrap existing renderer/signing behavior rather than becoming a separate product implementation.
 
 ## Rendering Model
 
@@ -84,7 +86,9 @@ Future styles should be added through the router, MCP contract, docs, and tests 
 
 - `Profile.key` is the public API/MCP key.
 - Public URLs should use `key`; do not expose or accept `profile_id` from public callers.
-- Hosted MCP auth lives in `core/mcp_auth.py`.
+- `core/mcp_auth.py` contains profile-key MCP auth helpers, but the current ASGI mount is intentionally unauthenticated for trial use.
+- User-scoped MCP tools still require an explicit OSIG profile key as a tool argument.
+- Re-enable hosted MCP auth before introducing paid production MCP access or private/admin tools.
 - Quota tracking lives in `core/usage.py` and `ProfileUsage`.
 - Subscription/customer state lives on `Profile` through dj-stripe models.
 - Watermark removal is tied to subscription status through `check_if_profile_has_pro_subscription`.
@@ -103,12 +107,14 @@ Future styles should be added through the router, MCP contract, docs, and tests 
 - The shared production image is built from `deployment/Dockerfile`.
 - `APP_PROCESS_TYPE=server` starts Gunicorn with `uvicorn_worker.UvicornWorker` against `osig.asgi:application`.
 - `APP_PROCESS_TYPE=worker` starts Django Q workers.
+- `APP_PROCESS_TYPE=mcp` starts the standalone FastMCP HTTP sidecar from `mcp_http_server.py`.
 - CapRover app names are `osig` and `osig-workers`.
 
 ## Technical Constraints
 
 - Do not weaken signature verification in `core/signing.py`.
-- Do not bypass MCP auth on hosted HTTP transport.
+- Do not expose private/admin MCP tools while hosted MCP remains unauthenticated.
+- Do not launch paid production MCP access until profile-key auth is re-enabled.
 - Do not add broad admin/database/file access to MCP.
 - Do not make rendering depend on external model image generation by default.
 - Keep generated image outputs deterministic for the same normalized params.

--- a/TECH.md
+++ b/TECH.md
@@ -1,0 +1,117 @@
+# Tech
+
+## Canonical Stack
+
+- Python/Django backend with Django 5.
+- Django Ninja for JSON API endpoints.
+- FastMCP for hosted and local MCP tooling.
+- Pillow for deterministic image rendering.
+- PostgreSQL for app data.
+- Redis and Django Q2 for background jobs.
+- dj-stripe and Stripe for subscription/customer state.
+- django-allauth for account/auth flows.
+- S3-compatible object storage for generated images.
+- webpack, Tailwind CSS, Stimulus, and Django templates for frontend assets.
+- PostHog, Plausible, Sentry, Logfire, structlog, and render-attempt records for analytics/observability.
+
+## Runtime And Tooling
+
+- Python version: project requires `>=3.10,<4.0`; production image currently uses Python 3.11.
+- JavaScript runtime: deployment asset build uses Node 24.15.0.
+- Python dependency manager: `uv`.
+- Frontend package manager: npm with `package-lock.json`.
+
+## Main Commands
+
+```bash
+cp .env.example .env
+make serve
+make test
+make test core/tests/test_mcp.py
+make shell
+make migrate
+npm run build
+uv run python mcp_server.py
+uv run fastmcp list --command "uv run python mcp_server.py"
+```
+
+## Primary Product Interfaces
+
+- Hosted MCP: `/mcp/`, authenticated with `X-API-Key` or `Authorization: Bearer <key>`.
+- Local MCP stdio: `uv run python mcp_server.py`.
+- Public render endpoint: `/g`.
+- Signed URL API: `POST /api/sign`.
+- Onboarding metadata API: `POST /api/onboarding/meta`.
+- WordPress helper API: `POST /api/integrations/wordpress`.
+- Admin render metrics API: `GET /api/admin/render-metrics`.
+
+## MCP Tool Contract
+
+The MCP source of truth is `core/mcp.py`.
+
+Current tools:
+
+- `get_image_generation_contract`
+- `normalize_image_params`
+- `render_image_preview`
+- `build_signed_image_url`
+- `list_recent_generated_images`
+- `get_recent_render_metrics`
+
+Keep MCP tools narrow, typed, and deterministic. They should wrap existing renderer/signing/metrics behavior rather than becoming a separate product implementation.
+
+## Rendering Model
+
+Image rendering starts in `core/image_styles.py` and shared utilities live in `core/image_utils.py`. Supported output formats are PNG and JPEG. Supported size presets are `x` and `meta`; `get_image_dimensions` currently returns half-size dimensions for the named social targets.
+
+Current style choices are:
+
+- `base`
+- `logo`
+- `job_classic`
+- `job_logo`
+- `job_clean`
+
+Current font choices are:
+
+- `helvetica`
+- `markerfelt`
+- `papyrus`
+
+Future styles should be added through the router, MCP contract, docs, and tests together.
+
+## Auth, Billing, Quotas
+
+- `Profile.key` is the public API/MCP key.
+- Public URLs should use `key`; do not expose or accept `profile_id` from public callers.
+- Hosted MCP auth lives in `core/mcp_auth.py`.
+- Quota tracking lives in `core/usage.py` and `ProfileUsage`.
+- Subscription/customer state lives on `Profile` through dj-stripe models.
+- Watermark removal is tied to subscription status through `check_if_profile_has_pro_subscription`.
+- Free hosted behavior should stay bounded by watermark and quota.
+
+## Reliability And Observability
+
+- Render error classification and metrics live in `core/render_observability.py`.
+- Render attempts are stored in `RenderAttempt`.
+- `/g` retries transient upstream fetch failures and records attempt duration/error type.
+- Admin metrics expose total attempts, failed attempts, fail rate, p95 render time, and error counts.
+
+## Deployment
+
+- Production deploys through GitHub Actions in `.github/workflows/deploy.yml`.
+- The shared production image is built from `deployment/Dockerfile`.
+- `APP_PROCESS_TYPE=server` starts Gunicorn with `uvicorn_worker.UvicornWorker` against `osig.asgi:application`.
+- `APP_PROCESS_TYPE=worker` starts Django Q workers.
+- CapRover app names are `osig` and `osig-workers`.
+
+## Technical Constraints
+
+- Do not weaken signature verification in `core/signing.py`.
+- Do not bypass MCP auth on hosted HTTP transport.
+- Do not add broad admin/database/file access to MCP.
+- Do not make rendering depend on external model image generation by default.
+- Keep generated image outputs deterministic for the same normalized params.
+- Preserve cache-busting with `v` and signed URL regeneration.
+- When changing renderer inputs, update MCP schema, public docs, tests, and UI examples.
+- Keep image fetch timeouts and retry taxonomy explicit.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,43 @@
+# Vision
+
+## Long-Term Direction
+
+OSIG should become the cheapest reliable way for personal AI agents to create social preview images and related code-generated visuals. The agent should not need a design model for every Open Graph image. It should call a tool, pass structured content, inspect a deterministic result, and commit or publish the asset.
+
+The product exists in a future where each person has an AI agent that builds apps, edits repos, and performs publishing work. OSIG gives those agents a narrow, useful capability: generate good-looking images with code instead of spending model tokens and image-generation credits.
+
+## Product Shape
+
+The primary interface is a hosted MCP/API service. The web app supports that service with account setup, API keys, billing, docs, examples, diagnostics, and a playground. The old direct `/g` endpoint can remain as a compatibility and rendering surface, but new product thinking should not revolve around users hand-building query strings.
+
+## What Should Never Drift
+
+- OSIG is deterministic image generation infrastructure, not an AI image model.
+- Agents are first-class users.
+- Structured inputs beat prompt-only inputs.
+- The hosted cloud service is paid by default for production use.
+- Open source self-hosting remains valid.
+- Tool contracts stay explicit, typed, inspectable, and safe.
+- Generated images must be useful in real social metadata, not just impressive in demos.
+
+## Strategic Bets
+
+- AI agents will choose cheaper deterministic tools when they produce good enough output.
+- Open Graph images are an ideal first wedge because they are repetitive, structured, and expensive to generate manually at scale.
+- MCP makes image generation available inside coding workflows where the resulting asset or metadata can be committed immediately.
+- Watermarking plus quotas is a practical boundary between open/demo usage and paid hosted production usage.
+
+## Non-Goals
+
+- Do not become a Canva clone.
+- Do not become a generic image-generation model wrapper.
+- Do not optimize first for anonymous web traffic.
+- Do not expose broad infrastructure controls through MCP.
+- Do not make the hosted service free by accident through compatibility paths.
+
+## Outcome-Level Success
+
+- An agent can add polished OG images to a repo faster and cheaper than using a model.
+- A developer can trust OSIG's signed URLs in production metadata.
+- A self-hoster can adapt the open source renderer without relying on OSIG cloud.
+- Paid hosted users understand what they are paying for: no watermark, higher quotas, reliable hosted generation, signed URLs, and agent-friendly tooling.


### PR DESCRIPTION
## Summary

Adds repository-level AI steering files for OSIG and updates the existing product/design steering docs around the AI-agent-first pivot.

## Details

- Adds AGENTS.md, VISION.md, TECH.md, and STRUCTURE.md.
- Updates PRODUCT.md to position OSIG as deterministic, code-generated image infrastructure for AI agents.
- Updates DESIGN.md to prioritize MCP/API workflows, agent-readable contracts, paid/free state clarity, and generated image quality constraints.

## Verification

- Ran `git diff --check`.
- Commit hooks ran documentation-safe checks: EOF fixer and trailing whitespace.
- No Django tests were run because the change is documentation-only.